### PR TITLE
Added support for proxy protocol mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6081100e960d9d74734659ffc9cc91daf1c0fc7aceb8eaa94ee1a3f5046f2e"
+checksum = "96816e1d921eca64d208a85aab4f7798455a8e34229ee5a88c935bdee1b78b14"
 dependencies = [
  "bytes 0.5.4",
  "futures-channel",
@@ -802,8 +802,7 @@ dependencies = [
 [[package]]
 name = "libunftp"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e8ecadd5e9bcc4ae9ed40c9c8a1e50c06a1ddde9caacf0b2f79a03fe492e796"
+source = "git+https://github.com/bolcom/libunftp#332a7856a3f87c2a878e3d18e634854a8317c111"
 dependencies = [
  "async-trait",
  "bytes 0.5.4",
@@ -822,6 +821,7 @@ dependencies = [
  "path_abs",
  "percent-encoding 2.1.0",
  "prometheus",
+ "proxy-protocol",
  "rand",
  "regex",
  "rustls 0.17.0",
@@ -1232,6 +1232,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e86d370532557ae7573551a1ec8235a0f8d6cb276c7c9e6aa490b511c447485"
 
 [[package]]
+name = "proxy-protocol"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7966d9d883d47c6b671173b6e005dc13a350cd4b6a94f7a4e19082b0eea1b57"
+dependencies = [
+ "bytes 0.5.4",
+ "thiserror",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1344,9 +1354,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.3.6"
+version = "1.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6946991529684867e47d86474e3a6d0c0ab9b82d5821e314b1ede31fa3a4b3"
+checksum = "a6020f034922e3194c711b82a627453881bc4682166cabb07134a10c26ba7692"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ readme = "README.md"
 
 [dependencies]
 async-trait = "0.1.30"
-libunftp = "0.9.0"
+libunftp = { git="https://github.com/bolcom/libunftp", branch="master" }
 log = "0.4"
 env_logger = "0.6"
 redis = "0.9.0"
@@ -31,7 +31,7 @@ slog-term = "2.4.0"
 slog-async = "2.3.0"
 slog-stdlog = "4.0.0"
 slog-scope = "4.0.0"
-hyper = "0.13"
+hyper = "0.13.5"
 http = "0.2.1"
 prometheus = "0.8"
 futures = "0.3"

--- a/Makefile
+++ b/Makefile
@@ -44,3 +44,12 @@ docker-run-%: docker-image-% # Run the % docker image in the foreground
 .PHONY: docker-list
 docker-list: # List the available docker images
 	@echo $(DOCKER_IMAGES)
+
+##
+.PHONY: pr-prep
+pr-prep: # Runs checks to ensure you're ready for a pull request
+	cargo fmt --all -- --check
+	cargo clippy --all-features -- -D warnings
+	cargo build --verbose --all --features rest_auth,jsonfile_auth,cloud_storage
+	cargo test --verbose --all --features rest_auth,jsonfile_auth,cloud_storage
+	cargo doc --all-features --no-deps

--- a/build.rs
+++ b/build.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 fn main() {
     let version = match Command::new("git").args(&["describe", "--tags"]).output() {
         Ok(output) => String::from_utf8(output.stdout).unwrap(),
-        Err(_) => env::var("BUILD_VERSION").unwrap_or(">unknown<".to_string()),
+        Err(_) => env::var("BUILD_VERSION").unwrap_or_else(|_| ">unknown<".to_string()),
     };
     println!("cargo:rustc-env=BUILD_VERSION={}", version);
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -17,6 +17,7 @@ pub const GCS_KEY_FILE: &str = "sbe-gcs-key-file";
 pub const HTTP_BIND_ADDR: &str = "bind-address-http";
 pub const IDLE_SESSION_TIMEOUT: &str = "idle-session-timeout";
 pub const PASSIVE_PORTS: &str = "passive-ports";
+pub const PROXY_EXTERNAL_CONTROL_ADDRES: &str = "proxy-external-control-address";
 pub const REDIS_HOST: &str = "log-redis-host";
 pub const REDIS_KEY: &str = "log-redis-key";
 pub const REDIS_PORT: &str = "log-redis-port";
@@ -60,7 +61,7 @@ pub(crate) fn clap_app(tmp_dir: &str) -> clap::App {
             Arg::with_name(BIND_ADDRESS)
                 .long("bind-address")
                 .value_name("HOST_PORT")
-                .help("Sets the host and port to listen on for FTP control connections")
+                .help("Sets the host and port to listen on for FTP(S) connections.")
                 .env("UNFTP_BIND_ADDRESS")
                 .takes_value(true)
                 .default_value("0.0.0.0:2121"),
@@ -69,7 +70,7 @@ pub(crate) fn clap_app(tmp_dir: &str) -> clap::App {
             Arg::with_name(ROOT_DIR)
                 .long("root-dir")
                 .value_name("PATH")
-                .help("Sets the FTP root directory")
+                .help("When the storage backend type is 'filesystem' this sets the path where files are stored.")
                 .env("UNFTP_ROOT_DIR")
                 .takes_value(true)
                 .default_value(tmp_dir),
@@ -127,7 +128,7 @@ pub(crate) fn clap_app(tmp_dir: &str) -> clap::App {
             Arg::with_name(PASSIVE_PORTS)
                 .long("passive-ports")
                 .value_name("PORT_RANGE")
-                .help("Sets the port range for data ports.")
+                .help("Sets the port range for data connections. In proxy protocol mode this resembles ports on the proxy.")
                 .env("UNFTP_PASSIVE_PORTS")
                 .takes_value(true)
                 .default_value("49152-65535"),
@@ -234,5 +235,13 @@ pub(crate) fn clap_app(tmp_dir: &str) -> clap::App {
                 .env("UNFTP_IDLE_SESSION_TIMEOUT")
                 .takes_value(true)
                 .default_value("600"),
+        )
+        .arg(
+            Arg::with_name(PROXY_EXTERNAL_CONTROL_ADDRES)
+                .long("proxy-external-control-address")
+                .value_name("HOST_PORT")
+                .help("This switches on proxy protocol mode and sets the external IP and external control port number for example 10.0.0.1:2121.")
+                .env("UNFTP_PROXY_EXTERNAL_CONTROL_ADDRES")
+                .takes_value(true),
         )
 }

--- a/src/redislog.rs
+++ b/src/redislog.rs
@@ -124,7 +124,7 @@ impl Builder {
         // TODO: Get something that works on windows too
         fn get_host_name() -> String {
             let output = Command::new("hostname").output().expect("failed to execute process");
-            String::from_utf8_lossy(&output.stdout).replace("\n", "").to_string()
+            String::from_utf8_lossy(&output.stdout).replace("\n", "")
         }
 
         let con_str = format!("redis://{}:{}", self.redis_host, self.redis_port);


### PR DESCRIPTION
libunftp will soon implement support for the [proxy protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt). See [the libunftp PR](https://github.com/bolcom/libunftp/pull/187). 

This PR adds support for the above-mentioned in unFTP.