### PR TITLE
Configure latest libunftp to use slog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,8 +751,7 @@ dependencies = [
 [[package]]
 name = "libunftp"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a120dba5a266aff32dbc99b63ad791023f263d3e9e3614d4a84b41658f4cbb70"
+source = "git+https://github.com/bolcom/libunftp.git?rev=8f7b446ebfef37f68f583076bd7355699e739b09#8f7b446ebfef37f68f583076bd7355699e739b09"
 dependencies = [
  "async-trait",
  "bytes 0.5.4",
@@ -764,7 +763,6 @@ dependencies = [
  "hyper-rustls",
  "itertools",
  "lazy_static",
- "log",
  "mime",
  "pam",
  "path_abs",
@@ -776,6 +774,8 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "slog",
+ "slog-stdlog",
  "tokio 0.2.20",
  "tokio-rustls",
  "tokio-util",
@@ -2016,8 +2016,6 @@ dependencies = [
  "serde_json",
  "slog",
  "slog-async",
- "slog-scope",
- "slog-stdlog",
  "slog-term",
  "tokio 0.2.20",
  "yup-oauth2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,8 @@ readme = "README.md"
 
 [dependencies]
 async-trait = "0.1.30"
-libunftp = "0.11.1"
+#libunftp = "0.11.1"
+libunftp = {git = "https://github.com/bolcom/libunftp.git", rev = "8f7b446ebfef37f68f583076bd7355699e739b09"}
 log = "0.4"
 env_logger = "0.6"
 redis = "0.9.0"
@@ -29,8 +30,6 @@ r2d2_redis = "0.8.0"
 slog = { version = "2.4.1", features = ["max_level_trace", "release_max_level_warn"] }
 slog-term = "2.4.0"
 slog-async = "2.3.0"
-slog-stdlog = "4.0.0"
-slog-scope = "4.0.0"
 hyper = "0.13.5"
 http = "0.2.1"
 prometheus = "0.8"

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -83,7 +83,7 @@ impl StorageBE {
         let path_str = path.as_ref().to_string_lossy().to_string();
         self.log.new(slog::o!(
         "username" => username,
-        "path" => path_str.clone()
+        "path" => path_str
         ))
     }
 }


### PR DESCRIPTION
This PR passes unFTP's structured [slog](https://crates.io/search?q=slog) logger to libunftp while cleanup up unFTP's logging dependencies and colourising log output:

![image](https://user-images.githubusercontent.com/2511554/85898850-504c2d80-b7fd-11ea-8c6e-77e52bb18c98.png)

