### PR TITLE
Added --ftps-required-on-control-channel option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cloudabi"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "combine"
 version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -644,7 +653,7 @@ dependencies = [
  "rustls 0.18.1",
  "rustls-native-certs 0.4.0",
  "tokio",
- "tokio-rustls 0.14.0",
+ "tokio-rustls 0.14.1",
  "webpki",
 ]
 
@@ -678,6 +687,12 @@ checksum = "076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "instant"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b141fdc7836c525d4d594027d318c84161ca17aaf8113ab1f81ab93ae897485"
 
 [[package]]
 name = "iovec"
@@ -758,8 +773,7 @@ dependencies = [
 [[package]]
 name = "libunftp"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f28b98626512a9774ea103a1b718226cf98e1718661b471bb7829b665303955"
+source = "git+https://github.com/bolcom/libunftp.git?rev=b1e75bd305d5060992bda64c13f139b35275677b#b1e75bd305d5060992bda64c13f139b35275677b"
 dependencies = [
  "async-trait",
  "bytes 0.5.6",
@@ -775,7 +789,7 @@ dependencies = [
  "pam",
  "path_abs",
  "percent-encoding 2.1.0",
- "prometheus",
+ "prometheus 0.10.0",
  "proxy-protocol",
  "rand",
  "regex",
@@ -785,7 +799,7 @@ dependencies = [
  "slog",
  "slog-stdlog",
  "tokio",
- "tokio-rustls 0.14.0",
+ "tokio-rustls 0.14.1",
  "tokio-util",
  "tracing",
  "tracing-attributes",
@@ -811,6 +825,15 @@ name = "lock_api"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28247cc5a5be2f05fbcd76dd0cf2c7d3b5400cb978a28042abcd4fa0b3f8261c"
 dependencies = [
  "scopeguard",
 ]
@@ -999,7 +1022,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 dependencies = [
- "lock_api",
+ "lock_api 0.3.4",
  "parking_lot_core 0.6.2",
  "rustc_version",
 ]
@@ -1010,8 +1033,19 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
 dependencies = [
- "lock_api",
+ "lock_api 0.3.4",
  "parking_lot_core 0.7.1",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4893845fa2ca272e647da5d0e46660a314ead9c2fdd9a883aabc32e481a8733"
+dependencies = [
+ "instant",
+ "lock_api 0.4.1",
+ "parking_lot_core 0.8.0",
 ]
 
 [[package]]
@@ -1021,7 +1055,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 dependencies = [
  "cfg-if",
- "cloudabi",
+ "cloudabi 0.0.3",
  "libc",
  "redox_syscall",
  "rustc_version",
@@ -1036,10 +1070,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e136c1904604defe99ce5fd71a28d473fa60a12255d511aa78a9ddf11237aeb"
 dependencies = [
  "cfg-if",
- "cloudabi",
+ "cloudabi 0.0.3",
  "libc",
  "redox_syscall",
- "smallvec 1.3.0",
+ "smallvec 1.4.2",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
+dependencies = [
+ "cfg-if",
+ "cloudabi 0.1.0",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec 1.4.2",
  "winapi 0.3.8",
 ]
 
@@ -1143,6 +1192,21 @@ dependencies = [
  "lazy_static",
  "protobuf",
  "spin",
+ "thiserror",
+]
+
+[[package]]
+name = "prometheus"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d70cf4412832bcac9cffe27906f4a66e450d323525e977168c70d1b36120ae"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "parking_lot 0.11.0",
+ "protobuf",
+ "regex",
  "thiserror",
 ]
 
@@ -1603,9 +1667,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.3.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05720e22615919e4734f6a99ceae50d00226c3c5aca406e102ebc33298214e0a"
+checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
 
 [[package]]
 name = "socket2"
@@ -1834,9 +1898,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "228139ddd4fea3fa345a29233009635235833e52807af7ea6448ead03890d6a9"
+checksum = "e12831b255bcfa39dc0436b01e19fea231a37db570686c06ee72c423479f889a"
 dependencies = [
  "futures-core",
  "rustls 0.18.1",
@@ -1961,7 +2025,7 @@ dependencies = [
  "hyper",
  "lazy_static",
  "libunftp",
- "prometheus",
+ "prometheus 0.9.0",
  "r2d2",
  "r2d2_redis",
  "redis",
@@ -1970,6 +2034,7 @@ dependencies = [
  "slog-async",
  "slog-term",
  "tokio",
+ "tokio-rustls 0.14.1",
  "yup-oauth2",
 ]
 
@@ -1988,7 +2053,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
 dependencies = [
- "smallvec 1.3.0",
+ "smallvec 1.4.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,8 @@ readme = "README.md"
 
 [dependencies]
 async-trait = "0.1.37"
-libunftp = "0.12.0"
+#libunftp = "0.12.0"
+libunftp = {git = "https://github.com/bolcom/libunftp.git", rev = "b1e75bd305d5060992bda64c13f139b35275677b"}
 redis = "0.9.0"
 serde_json = "1.0.57"
 chrono = "0.4.6"
@@ -35,6 +36,7 @@ tokio = { version = "0.2", features = ["full"] }
 clap = "2.33.3"
 yup-oauth2 = { version = "4.1.0", optional = true }
 lazy_static = "1.4.0"
+tokio-rustls= "0.14.1" # Added only to resolve conflicts
 
 [features]
 pam_auth = ["libunftp/pam_auth"]

--- a/src/args.rs
+++ b/src/args.rs
@@ -12,6 +12,7 @@ pub const AUTH_TYPE: &str = "auth-type";
 pub const BIND_ADDRESS: &str = "bind-address";
 pub const FTPS_CERTS_FILE: &str = "ftps-certs-file";
 pub const FTPS_KEY_FILE: &str = "ftps-key-file";
+pub const FTPS_REQUIRED_ON_CONTROL_CHANNEL: &str = "ftps-required-on-control-channel";
 pub const GCS_BASE_URL: &str = "sbe-gcs-base-url";
 pub const GCS_BUCKET: &str = "sbe-gcs-bucket";
 pub const GCS_KEY_FILE: &str = "sbe-gcs-key-file";
@@ -31,7 +32,7 @@ pub const VERBOSITY: &str = "verbosity";
 arg_enum! {
     #[derive(Debug)]
     #[allow(non_camel_case_types)]
-    enum AuthType {
+    pub enum AuthType {
         anonymous,
         pam,
         rest,
@@ -42,9 +43,19 @@ arg_enum! {
 arg_enum! {
     #[derive(Debug)]
     #[allow(non_camel_case_types)]
-    enum StorageBackendType {
+    pub enum StorageBackendType {
         filesystem,
         gcs,
+    }
+}
+
+arg_enum! {
+    #[derive(Debug)]
+    #[allow(non_camel_case_types)]
+    pub enum FtpsRequiredType {
+        all,
+        accounts,
+        none,
     }
 }
 
@@ -94,6 +105,19 @@ pub(crate) fn clap_app(tmp_dir: &str) -> clap::App {
                 .help("Sets the path to the private key file (PEM format) used for TLS security")
                 .env("UNFTP_FTPS_KEY_FILE")
                 .takes_value(true)
+                .requires(FTPS_CERTS_FILE),
+        )
+        .arg(
+            Arg::with_name(FTPS_REQUIRED_ON_CONTROL_CHANNEL)
+                .long("ftps-required-on-control-channel")
+                .value_name("REQUIRE_SETTING")
+                .help("Sets whether FTP clients are required to upgrade to FTPS. The difference \
+                          between 'all' and 'accounts' is that the latter does not enforce FTPS on \
+                          anonymous logins i.e. it applies to accounts only")
+                .env("UNFTP_FTPS_REQUIRED_ON_CONTROL_CHANNEL")
+                .possible_values(&FtpsRequiredType::variants())
+                .takes_value(true)
+                .default_value("none")
                 .requires(FTPS_CERTS_FILE),
         )
         .arg(


### PR DESCRIPTION
This adds a new command line option to unFTP that leverages [new functionality in libunftp](https://github.com/bolcom/libunftp/pull/259)

An excerpt from the startup log:

![image](https://user-images.githubusercontent.com/2511554/92254331-048ac400-eed1-11ea-949c-8fb2cb005b6b.png)
