### PR TITLE
Added --ftps-required-on-data-channel option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,6 +346,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "298998b1cf6b5b2c8a7b023dfd45821825ce3ba8a8af55c921a0e734e4653f76"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dirs"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -773,11 +784,12 @@ dependencies = [
 [[package]]
 name = "libunftp"
 version = "0.12.0"
-source = "git+https://github.com/bolcom/libunftp.git?rev=b1e75bd305d5060992bda64c13f139b35275677b#b1e75bd305d5060992bda64c13f139b35275677b"
+source = "git+https://github.com/bolcom/libunftp.git?rev=d91004c27260e0b040125465f09d61fba26a0ec3#d91004c27260e0b040125465f09d61fba26a0ec3"
 dependencies = [
  "async-trait",
  "bytes 0.5.6",
  "chrono",
+ "derive_more",
  "failure",
  "failure_derive",
  "futures 0.3.5",
@@ -798,6 +810,7 @@ dependencies = [
  "serde_json",
  "slog",
  "slog-stdlog",
+ "thiserror",
  "tokio",
  "tokio-rustls 0.14.1",
  "tokio-util",
@@ -1761,18 +1774,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.15"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b3d3d2ff68104100ab257bb6bb0cb26c901abe4bd4ba15961f3bf867924012"
+checksum = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.15"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca972988113b7715266f91250ddb98070d033c62a011fa0fcc57434a649310dd"
+checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2033,6 +2046,7 @@ dependencies = [
  "slog",
  "slog-async",
  "slog-term",
+ "thiserror",
  "tokio",
  "tokio-rustls 0.14.1",
  "yup-oauth2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,7 @@ readme = "README.md"
 
 [dependencies]
 async-trait = "0.1.37"
-#libunftp = "0.12.0"
-libunftp = {git = "https://github.com/bolcom/libunftp.git", rev = "b1e75bd305d5060992bda64c13f139b35275677b"}
+libunftp = {git = "https://github.com/bolcom/libunftp.git", rev = "d91004c27260e0b040125465f09d61fba26a0ec3"}
 redis = "0.9.0"
 serde_json = "1.0.57"
 chrono = "0.4.6"
@@ -36,7 +35,8 @@ tokio = { version = "0.2", features = ["full"] }
 clap = "2.33.3"
 yup-oauth2 = { version = "4.1.0", optional = true }
 lazy_static = "1.4.0"
-tokio-rustls= "0.14.1" # Added only to resolve conflicts
+tokio-rustls = "0.14.1" # Added only to resolve conflicts
+thiserror = "1.0.20" # Added only to resolve conflicts
 
 [features]
 pam_auth = ["libunftp/pam_auth"]

--- a/src/args.rs
+++ b/src/args.rs
@@ -13,6 +13,7 @@ pub const BIND_ADDRESS: &str = "bind-address";
 pub const FTPS_CERTS_FILE: &str = "ftps-certs-file";
 pub const FTPS_KEY_FILE: &str = "ftps-key-file";
 pub const FTPS_REQUIRED_ON_CONTROL_CHANNEL: &str = "ftps-required-on-control-channel";
+pub const FTPS_REQUIRED_ON_DATA_CHANNEL: &str = "ftps-required-on-data-channel";
 pub const GCS_BASE_URL: &str = "sbe-gcs-base-url";
 pub const GCS_BUCKET: &str = "sbe-gcs-bucket";
 pub const GCS_KEY_FILE: &str = "sbe-gcs-key-file";
@@ -111,7 +112,20 @@ pub(crate) fn clap_app(tmp_dir: &str) -> clap::App {
             Arg::with_name(FTPS_REQUIRED_ON_CONTROL_CHANNEL)
                 .long("ftps-required-on-control-channel")
                 .value_name("REQUIRE_SETTING")
-                .help("Sets whether FTP clients are required to upgrade to FTPS. The difference \
+                .help("Sets whether FTP clients are required to upgrade to FTPS on the control channel. The difference \
+                          between 'all' and 'accounts' is that the latter does not enforce FTPS on \
+                          anonymous logins i.e. it applies to accounts only")
+                .env("UNFTP_FTPS_REQUIRED_ON_CONTROL_CHANNEL")
+                .possible_values(&FtpsRequiredType::variants())
+                .takes_value(true)
+                .default_value("none")
+                .requires(FTPS_CERTS_FILE),
+        )
+        .arg(
+            Arg::with_name(FTPS_REQUIRED_ON_DATA_CHANNEL)
+                .long("ftps-required-on-data-channel")
+                .value_name("REQUIRE_SETTING")
+                .help("Sets whether FTP clients are required to upgrade to FTPS on the data channel. The difference \
                           between 'all' and 'accounts' is that the latter does not enforce FTPS on \
                           anonymous logins i.e. it applies to accounts only")
                 .env("UNFTP_FTPS_REQUIRED_ON_CONTROL_CHANNEL")

--- a/src/user.rs
+++ b/src/user.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use libunftp::auth::{DefaultUser, UserDetail};
+use libunftp::auth::{AuthenticationError, DefaultUser, UserDetail};
 use std::fmt::Formatter;
 
 #[derive(Debug, PartialEq)]
@@ -49,11 +49,7 @@ impl LookupAuthenticator {
 
 #[async_trait]
 impl libunftp::auth::Authenticator<User> for LookupAuthenticator {
-    async fn authenticate(
-        &self,
-        username: &str,
-        password: &str,
-    ) -> Result<User, Box<dyn std::error::Error + Send + Sync>> {
+    async fn authenticate(&self, username: &str, password: &str) -> Result<User, AuthenticationError> {
         self.inner.authenticate(username, password).await?;
         // TODO: User successfully authenticated, now lookup user details from repository e.g. PostgreSql
         Ok(User {


### PR DESCRIPTION
This PR adds support for new functionality in `libunftp` whereby TLS may be set as required for data channel connections.