### PR TITLE
Added environment variable UNFTP_LOG_LEVEL and ...

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,9 +347,9 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.9"
+version = "0.99.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298998b1cf6b5b2c8a7b023dfd45821825ce3ba8a8af55c921a0e734e4653f76"
+checksum = "1dcfabdab475c16a93d669dddfc393027803e347d09663f524447f642fbb84ba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1737,9 +1737,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
+checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/args.rs
+++ b/src/args.rs
@@ -29,6 +29,7 @@ pub const REDIS_PORT: &str = "log-redis-port";
 pub const ROOT_DIR: &str = "root-dir";
 pub const STORAGE_BACKEND_TYPE: &str = "sbe-type";
 pub const VERBOSITY: &str = "verbosity";
+pub const LOG_LEVEL: &str = "log-level";
 
 arg_enum! {
     #[derive(Debug)]
@@ -60,6 +61,18 @@ arg_enum! {
     }
 }
 
+arg_enum! {
+    #[derive(Debug)]
+    #[allow(non_camel_case_types)]
+    pub enum LogLevelType {
+        error,
+        warn,
+        info,
+        debug,
+        trace,
+    }
+}
+
 pub(crate) fn clap_app(tmp_dir: &str) -> clap::App {
     App::new(app::NAME)
         .version(app::VERSION)
@@ -70,7 +83,16 @@ pub(crate) fn clap_app(tmp_dir: &str) -> clap::App {
             Arg::with_name(VERBOSITY)
                 .short("v")
                 .multiple(true)
-                .help("verbosity level"),
+                .help("verbosity level")
+        )
+        .arg(
+            Arg::with_name(LOG_LEVEL)
+                .long("log-level")
+                .value_name("LEVEL")
+                .help("Sets the logging level. This overrides the verbosity flag -v if it is also specified.")
+                .env("UNFTP_LOG_LEVEL")
+                .possible_values(&LogLevelType::variants())
+                .takes_value(true)
         )
         .arg(
             Arg::with_name(BIND_ADDRESS)
@@ -119,7 +141,6 @@ pub(crate) fn clap_app(tmp_dir: &str) -> clap::App {
                 .possible_values(&FtpsRequiredType::variants())
                 .takes_value(true)
                 .default_value("none")
-                .requires(FTPS_CERTS_FILE),
         )
         .arg(
             Arg::with_name(FTPS_REQUIRED_ON_DATA_CHANNEL)
@@ -132,7 +153,6 @@ pub(crate) fn clap_app(tmp_dir: &str) -> clap::App {
                 .possible_values(&FtpsRequiredType::variants())
                 .takes_value(true)
                 .default_value("none")
-                .requires(FTPS_CERTS_FILE),
         )
         .arg(
             Arg::with_name(REDIS_KEY)

--- a/src/main.rs
+++ b/src/main.rs
@@ -407,6 +407,17 @@ fn create_logger(arg_matches: &ArgMatches) -> Result<slog::Logger, String> {
         _ => slog::Level::Trace,
     };
 
+    let min_log_level = match arg_matches.value_of(args::LOG_LEVEL) {
+        Some(level) => match level.parse::<args::LogLevelType>()? {
+            args::LogLevelType::error => slog::Level::Error,
+            args::LogLevelType::warn => slog::Level::Warning,
+            args::LogLevelType::info => slog::Level::Info,
+            args::LogLevelType::debug => slog::Level::Debug,
+            args::LogLevelType::trace => slog::Level::Trace,
+        },
+        None => min_log_level,
+    };
+
     let decorator = slog_term::TermDecorator::new().force_color().build();
     let term_drain = slog_term::FullFormat::new(decorator)
         .build()


### PR DESCRIPTION
... fixed broken `--ftps-required-on-control-channel` and `--ftps-required-on-data-channel` that caused unFTP to not start if certificate files were note specified.