### PR TITLE
Moved redislog module to its own sub-crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -771,7 +771,7 @@ dependencies = [
  "pam",
  "path_abs",
  "percent-encoding 2.1.0",
- "prometheus 0.10.0",
+ "prometheus",
  "proxy-protocol",
  "rand",
  "regex",
@@ -1142,20 +1142,6 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0ced56dee39a6e960c15c74dc48849d614586db2eaada6497477af7c7811cd"
-dependencies = [
- "cfg-if",
- "fnv",
- "lazy_static",
- "protobuf",
- "spin",
- "thiserror",
-]
-
-[[package]]
-name = "prometheus"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30d70cf4412832bcac9cffe27906f4a66e450d323525e977168c70d1b36120ae"
@@ -1271,6 +1257,18 @@ dependencies = [
  "tokio-io",
  "tokio-tcp",
  "url 1.7.2",
+]
+
+[[package]]
+name = "redislog"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "r2d2",
+ "r2d2_redis",
+ "redis",
+ "serde_json",
+ "slog",
 ]
 
 [[package]]
@@ -1966,18 +1964,14 @@ version = "0.12.0"
 dependencies = [
  "async-trait",
  "built",
- "chrono",
  "clap",
  "futures 0.3.5",
  "http",
  "hyper",
  "lazy_static",
  "libunftp",
- "prometheus 0.9.0",
- "r2d2",
- "r2d2_redis",
- "redis",
- "serde_json",
+ "prometheus",
+ "redislog",
  "slog",
  "slog-async",
  "slog-term",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,20 +16,20 @@ repository = "https://github.com/bolcom/unFTP"
 license = "Apache-2.0"
 readme = "README.md"
 
+[workspace]
+
+[dependencies.redislog]
+path="crates/redislog"
+
 [dependencies]
 async-trait = "0.1.37"
 libunftp = {git = "https://github.com/bolcom/libunftp.git", rev = "52c9a9109a3b62c69ebbc4287db0ca6fdcebbcdf"}
-redis = "0.9.0"
-serde_json = "1.0.57"
-chrono = "0.4.6"
-r2d2 = "0.8.3"
-r2d2_redis = "0.8.0"
 slog = { version = "2.4.1", features = ["max_level_trace", "release_max_level_info"] }
 slog-term = "2.6.0"
 slog-async = "2.3.0"
 hyper = "0.13.7"
 http = "0.2.1"
-prometheus = "0.9.0"
+prometheus = "0.10.0"
 futures = "0.3"
 tokio = { version = "0.2", features = ["full"] }
 clap = "2.33.3"
@@ -56,3 +56,7 @@ static = []
 
 [build-dependencies]
 built = "0.3"
+
+[profile.release]
+debug = false
+# lto = true

--- a/crates/redislog/Cargo.toml
+++ b/crates/redislog/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "redislog"
+version = "0.1.0"
+authors = ["Hannes de Jager <hdejager@bol.com>"]
+edition = "2018"
+license = "Apache-2.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+chrono = "0.4.6"
+r2d2 = "0.8.3"
+r2d2_redis = "0.8.0"
+redis = "0.9.0"
+serde_json = "1.0.57"
+slog = { version = "2.4.1", features = ["max_level_trace", "release_max_level_info"] }

--- a/crates/redislog/src/lib.rs
+++ b/crates/redislog/src/lib.rs
@@ -1,3 +1,5 @@
+//! This crate implements a [slog](https://crates.io/crates/slog) logger that outputs to a Redis list in a structured way.
+
 use std::cell::RefCell;
 use std::fmt;
 use std::process::Command;
@@ -12,6 +14,7 @@ use slog::{OwnedKVList, Record, KV};
 
 /// A logger that sends JSON formatted logs to a list in a Redis instance. It uses this format
 ///
+/// ```json
 ///   {
 ///     "@timestamp": ${timeRFC3339},
 ///     "@source_host": ${hostname},
@@ -23,14 +26,11 @@ use slog::{OwnedKVList, Record, KV};
 ///        ... // logged field 2
 ///        ...
 ///    }
+/// ```
 ///
-/// It supports structured logging via [`slog`][slog-url] and also implements the `Log`
-/// trait from the [`log` crate][log-crate-url].
+/// It supports structured logging via [`slog`][slog-url]. You can use the [`Builder`] to
+/// construct it and then use it as an slog drain.
 ///
-/// You can use the [`Builder`] to construct it and then use it as an slog drain or install it with
-/// the [`log` crate][log-crate-url].
-///
-/// [log-crate-url]: https://docs.rs/log/
 /// [`Builder`]: struct.Builder.html
 /// [slog-url]: https://github.com/slog-rs/slog
 #[derive(Debug)]

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,73 @@
+use crate::app;
+use crate::args;
+
+use clap::ArgMatches;
+use slog::*;
+use std::result::Result;
+
+pub fn create_logger(arg_matches: &ArgMatches) -> Result<slog::Logger, String> {
+    let min_log_level = match arg_matches.occurrences_of(args::VERBOSITY) {
+        0 => slog::Level::Warning,
+        1 => slog::Level::Info,
+        2 => slog::Level::Debug,
+        _ => slog::Level::Trace,
+    };
+
+    let min_log_level = match arg_matches.value_of(args::LOG_LEVEL) {
+        Some(level) => match level.parse::<args::LogLevelType>()? {
+            args::LogLevelType::error => slog::Level::Error,
+            args::LogLevelType::warn => slog::Level::Warning,
+            args::LogLevelType::info => slog::Level::Info,
+            args::LogLevelType::debug => slog::Level::Debug,
+            args::LogLevelType::trace => slog::Level::Trace,
+        },
+        None => min_log_level,
+    };
+
+    let decorator = slog_term::TermDecorator::new().force_color().build();
+    let term_drain = slog_term::FullFormat::new(decorator)
+        .build()
+        .filter_level(min_log_level)
+        .fuse();
+
+    let drain = match redis_logger(&arg_matches)? {
+        Some(redis_logger) => {
+            let both = slog::Duplicate::new(redis_logger, term_drain).fuse();
+            slog_async::Async::new(both.filter_level(min_log_level).fuse())
+                .build()
+                .fuse()
+        }
+        None => slog_async::Async::new(term_drain).build().fuse(),
+    };
+    let root = Logger::root(drain, o!());
+    let log = root.new(o!());
+    Ok(log)
+}
+
+fn redis_logger(m: &clap::ArgMatches) -> Result<Option<redislog::Logger>, String> {
+    match (
+        m.value_of(args::REDIS_KEY),
+        m.value_of(args::REDIS_HOST),
+        m.value_of(args::REDIS_PORT),
+    ) {
+        (Some(key), Some(host), Some(port)) => {
+            let instance_name = m.value_of(args::INSTANCE_NAME).unwrap();
+            let app_name = if instance_name == app::NAME {
+                String::from(app::NAME)
+            } else {
+                format!("{}-{}", app::NAME, instance_name)
+            };
+            let logger = redislog::Builder::new(&*app_name)
+                .redis(
+                    String::from(host),
+                    String::from(port).parse::<u32>().unwrap(),
+                    String::from(key),
+                )
+                .build()
+                .map_err(|e| format!("could not initialize Redis logger: {}", e))?;
+            Ok(Some(logger))
+        }
+        (None, None, None) => Ok(None),
+        _ => Err("for the redis logger please specify all --log-redis-* options".to_string()),
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,8 +8,8 @@ extern crate clap;
 mod app;
 mod args;
 mod http;
+mod logging;
 mod metrics;
-mod redislog;
 mod storage;
 mod user;
 
@@ -35,34 +35,6 @@ use user::LookupAuthenticator;
 #[cfg(feature = "pam_auth")]
 use libunftp::auth::pam;
 use libunftp::options::FtpsRequired;
-
-fn redis_logger(m: &clap::ArgMatches) -> Result<Option<redislog::Logger>, String> {
-    match (
-        m.value_of(args::REDIS_KEY),
-        m.value_of(args::REDIS_HOST),
-        m.value_of(args::REDIS_PORT),
-    ) {
-        (Some(key), Some(host), Some(port)) => {
-            let instance_name = m.value_of(args::INSTANCE_NAME).unwrap();
-            let app_name = if instance_name == app::NAME {
-                String::from(app::NAME)
-            } else {
-                format!("{}-{}", app::NAME, instance_name)
-            };
-            let logger = redislog::Builder::new(&*app_name)
-                .redis(
-                    String::from(host),
-                    String::from(port).parse::<u32>().unwrap(),
-                    String::from(key),
-                )
-                .build()
-                .map_err(|e| format!("could not initialize Redis logger: {}", e))?;
-            Ok(Some(logger))
-        }
-        (None, None, None) => Ok(None),
-        _ => Err("for the redis logger please specify all --log-redis-* options".to_string()),
-    }
-}
 
 fn make_auth(m: &clap::ArgMatches) -> Result<Arc<dyn auth::Authenticator<user::User> + Send + Sync>, String> {
     match m.value_of(args::AUTH_TYPE) {
@@ -399,47 +371,8 @@ async fn main_task(arg_matches: ArgMatches<'_>, log: &Logger, root_log: &Logger)
     listen_for_signals().await
 }
 
-fn create_logger(arg_matches: &ArgMatches) -> Result<slog::Logger, String> {
-    let min_log_level = match arg_matches.occurrences_of(args::VERBOSITY) {
-        0 => slog::Level::Warning,
-        1 => slog::Level::Info,
-        2 => slog::Level::Debug,
-        _ => slog::Level::Trace,
-    };
-
-    let min_log_level = match arg_matches.value_of(args::LOG_LEVEL) {
-        Some(level) => match level.parse::<args::LogLevelType>()? {
-            args::LogLevelType::error => slog::Level::Error,
-            args::LogLevelType::warn => slog::Level::Warning,
-            args::LogLevelType::info => slog::Level::Info,
-            args::LogLevelType::debug => slog::Level::Debug,
-            args::LogLevelType::trace => slog::Level::Trace,
-        },
-        None => min_log_level,
-    };
-
-    let decorator = slog_term::TermDecorator::new().force_color().build();
-    let term_drain = slog_term::FullFormat::new(decorator)
-        .build()
-        .filter_level(min_log_level)
-        .fuse();
-
-    let drain = match redis_logger(&arg_matches)? {
-        Some(redis_logger) => {
-            let both = slog::Duplicate::new(redis_logger, term_drain).fuse();
-            slog_async::Async::new(both.filter_level(min_log_level).fuse())
-                .build()
-                .fuse()
-        }
-        None => slog_async::Async::new(term_drain).build().fuse(),
-    };
-    let root = Logger::root(drain, o!());
-    let log = root.new(o!());
-    Ok(log)
-}
-
 fn run(arg_matches: ArgMatches) -> Result<(), String> {
-    let root_logger = create_logger(&arg_matches)?;
+    let root_logger = logging::create_logger(&arg_matches)?;
     let log = root_logger.new(o!("module" => "main"));
 
     let addr = String::from(arg_matches.value_of(args::BIND_ADDRESS).unwrap());

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -3,12 +3,10 @@ use async_trait::async_trait;
 use libunftp::storage::Result;
 use libunftp::storage::{Fileinfo, StorageBackend};
 use std::fmt::Debug;
+use std::io::Cursor;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::SystemTime;
-use std::io::Cursor;
-use libunftp::storage::cloud_storage::CloudStorage;
-use libunftp::storage::filesystem::Filesystem;
 
 #[derive(Debug)]
 pub enum InnerStorage {
@@ -137,27 +135,39 @@ impl StorageBackend<User> for StorageBE {
         }
     }
 
-    async fn list_fmt<P>(&self, user: &Option<User>, path: P) -> Result<Cursor<Vec<u8>>> where
+    async fn list_fmt<P>(&self, user: &Option<User>, path: P) -> Result<Cursor<Vec<u8>>>
+    where
         P: AsRef<Path> + Send + Debug,
-        Self::Metadata: libunftp::storage::Metadata + 'static, {
+        Self::Metadata: libunftp::storage::Metadata + 'static,
+    {
         match &self.inner {
             InnerStorage::Cloud(i) => i.list_fmt(user, path).await,
             InnerStorage::File(i) => i.list_fmt(user, path).await,
         }
     }
 
-    async fn nlst<P>(&self, user: &Option<User>, path: P) -> std::io::Result<Cursor<Vec<u8>>> where
+    async fn nlst<P>(&self, user: &Option<User>, path: P) -> std::io::Result<Cursor<Vec<u8>>>
+    where
         P: AsRef<Path> + Send + Debug,
-        Self::Metadata: libunftp::storage::Metadata + 'static, {
+        Self::Metadata: libunftp::storage::Metadata + 'static,
+    {
         match &self.inner {
             InnerStorage::Cloud(i) => i.nlst(user, path).await,
             InnerStorage::File(i) => i.nlst(user, path).await,
         }
     }
 
-    async fn get_into<'a, P, W: ?Sized>(&self, user: &Option<User>, path: P, start_pos: u64, output: &'a mut W) -> Result<u64> where
+    async fn get_into<'a, P, W: ?Sized>(
+        &self,
+        user: &Option<User>,
+        path: P,
+        start_pos: u64,
+        output: &'a mut W,
+    ) -> Result<u64>
+    where
         W: tokio::io::AsyncWrite + Unpin + Sync + Send,
-        P: AsRef<Path> + Send + Debug, {
+        P: AsRef<Path> + Send + Debug,
+    {
         match &self.inner {
             InnerStorage::Cloud(i) => i.get_into(user, path, start_pos, output).await,
             InnerStorage::File(i) => i.get_into(user, path, start_pos, output).await,
@@ -231,6 +241,4 @@ impl StorageBackend<User> for StorageBE {
             InnerStorage::File(i) => i.cwd(user, path).await,
         }
     }
-
-
 }


### PR DESCRIPTION
This MR moves the _redis logger_ to its own sub-crate as a best practice.  It also moves logging related functions from the main module to a `logging` sub module.

Some unrelated formatting also.
