### PR TITLE
Draft: Added support for k8s workload identity.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,27 +43,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
-name = "async-stream"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3670df70cbc01729f901f94c887814b3c68db038aad1329a418bae178bc5295c"
-dependencies = [
- "async-stream-impl",
- "futures-core",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3548b8efc9f8e8a5a0a2808c5bd8451a9031b9e5b879a79590304ae928b0a70"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -374,9 +353,9 @@ checksum = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
 
 [[package]]
 name = "futures"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b3b0c040a1fe6529d30b3c5944b280c7f0dcb2930d2c3062bca967b602583d0"
+checksum = "c70be434c505aee38639abccb918163b63158a4b4bb791b45b7023044bdc3c9c"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -389,9 +368,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7109687aa4e177ef6fe84553af6280ef2778bdb7783ba44c9dc3399110fe64"
+checksum = "f01c61843314e95f96cc9245702248733a3a3d744e43e2e755e3c7af8348a0a9"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -399,15 +378,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "847ce131b72ffb13b6109a221da9ad97a64cbe48feb1028356b836b47b8f1748"
+checksum = "db8d3b0917ff63a2a96173133c02818fac4a746b0a57569d3baca9ec0e945e08"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4caa2b2b68b880003057c1dd49f1ed937e38f22fcf6c212188a121f08cf40a65"
+checksum = "9ee9ca2f7eb4475772cf39dd1cd06208dce2670ad38f4d9c7262b3e15f127068"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -416,15 +395,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611834ce18aaa1bd13c4b374f5d653e1027cf99b6b502584ff8c9a64413b30bb"
+checksum = "e37c1a51b037b80922864b8eed90692c5cd8abd4c71ce49b77146caa47f3253b"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77408a692f1f97bcc61dc001d752e00643408fbc922e4d634c655df50d595556"
+checksum = "0f8719ca0e1f3c5e34f3efe4570ef2c0610ca6da85ae7990d472e9cbfba13664"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -434,24 +413,24 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f878195a49cee50e006b02b93cf7e0a95a38ac7b776b4c4d9cc1207cd20fcb3d"
+checksum = "f6adabac1290109cfa089f79192fb6244ad2c3f1cc2281f3e1dd987592b71feb"
 
 [[package]]
 name = "futures-task"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c554eb5bf48b2426c4771ab68c6b14468b6e76cc90996f528c3338d761a4d0d"
+checksum = "a92a0843a2ff66823a8f7c77bffe9a09be2b64e533562c412d63075643ec0038"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "futures-util"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d304cff4a7b99cfb7986f7d43fbe93d175e72e704a8860787cc95e9ffd85cbd2"
+checksum = "036a2107cdeb57f6d7322f1b6c363dad67cd63ca3b7d1b925bdf75bd5d96cda9"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -460,7 +439,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project 1.0.1",
+ "pin-project-lite",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -566,9 +545,9 @@ checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
 name = "hyper"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b980c7bc75203b968f06374cbde00bf1818e02e156b8e5b6ccf440fb53b6d0"
+checksum = "12219dc884514cb4a6a03737f4413c0e01c23a1b059b0156004b23f1e19dccbe"
 dependencies = [
  "bytes 1.0.0",
  "futures-channel",
@@ -720,15 +699,15 @@ dependencies = [
 
 [[package]]
 name = "libunftp"
-version = "0.14.1"
-source = "git+https://github.com/bolcom/libunftp.git?rev=4410a94f9835de3c8f0e48ffb41ab0a4be338289#4410a94f9835de3c8f0e48ffb41ab0a4be338289"
+version = "0.15.0"
+source = "git+https://github.com/bolcom/libunftp.git?rev=293a8e7dc8741f372b27ee191cbda1eecc32f185#293a8e7dc8741f372b27ee191cbda1eecc32f185"
 dependencies = [
  "async-trait",
  "bytes 0.5.6",
  "bytes 1.0.0",
  "chrono",
  "derive_more",
- "futures 0.3.8",
+ "futures 0.3.9",
  "hyper",
  "hyper-rustls",
  "itertools",
@@ -739,7 +718,7 @@ dependencies = [
  "percent-encoding 2.1.0",
  "prometheus",
  "proxy-protocol",
- "rand 0.8.0",
+ "rand 0.8.1",
  "regex",
  "rustls",
  "serde",
@@ -1217,9 +1196,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76330fb486679b4ace3670f117bbc9e16204005c4bde9c4bd372f45bed34f12"
+checksum = "c24fcd450d3fa2b592732565aa4f17a27a61c65ece4726353e000939b0edee34"
 dependencies = [
  "libc",
  "rand_chacha 0.3.0",
@@ -1503,9 +1482,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1500e84d27fe482ed1dc791a56eddc2f230046a040fa908c08bda1d9fb615779"
+checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
 dependencies = [
  "itoa",
  "ryu",
@@ -1824,11 +1803,10 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f3be913b74b13210c8fe04b17ab833f5a124f45b93d0f99f59fff621f64392a"
+checksum = "e4cdeb73537e63f98adcd73138af75e3f368ccaecffaa29d7eb61b9f5a440457"
 dependencies = [
- "async-stream",
  "futures-core",
  "pin-project-lite",
  "tokio",
@@ -1927,7 +1905,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
 dependencies = [
- "futures 0.3.8",
+ "futures 0.3.9",
  "futures-task",
  "pin-project 0.4.23",
  "tracing",
@@ -1946,7 +1924,7 @@ dependencies = [
  "async-trait",
  "built",
  "clap",
- "futures 0.3.8",
+ "futures 0.3.9",
  "http",
  "hyper",
  "lazy_static",
@@ -1957,7 +1935,6 @@ dependencies = [
  "slog-redis",
  "slog-term",
  "tokio",
- "yup-oauth2",
 ]
 
 [[package]]
@@ -2205,7 +2182,7 @@ checksum = "b7a18517c6f016cdb1801280b648a20fd23980df74720b07a06f8cd74a3e2ea8"
 dependencies = [
  "base64 0.12.3",
  "chrono",
- "futures 0.3.8",
+ "futures 0.3.9",
  "http",
  "hyper",
  "hyper-rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,21 +29,20 @@ version="0.1.0"
 [dependencies]
 async-trait = "0.1.41"
 clap = "2.33.3"
-futures = "0.3"
+futures = "0.3.9"
 http = "0.2.2"
 hyper = { version = "0.14.1", features = ["server", "http1"] }
 lazy_static = "1.4.0"
-libunftp = { git = "https://github.com/bolcom/libunftp.git", rev="4410a94f9835de3c8f0e48ffb41ab0a4be338289" }
+libunftp = { git = "https://github.com/bolcom/libunftp.git", rev="293a8e7dc8741f372b27ee191cbda1eecc32f185" }
 prometheus = "0.10.0"
 slog = { version = "2.5.2", features = ["max_level_trace", "release_max_level_info"] }
 slog-async = "2.5.0"
 slog-term = "2.6.0"
 tokio = { version = "1.0.1", features = ["full"] }
-yup-oauth2 = {version = "5.0.1", optional = true}
 
 [features]
 all = ["pam_auth", "rest_auth", "jsonfile_auth", "cloud_storage"]
-cloud_storage = ["libunftp/cloud_storage", "yup-oauth2"]
+cloud_storage = ["libunftp/cloud_storage"]
 jsonfile_auth = ["libunftp/jsonfile_auth"]
 pam_auth = ["libunftp/pam_auth"]
 rest_auth = ["libunftp/rest_auth"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-RUST_VERSION=1.47.0
+RUST_VERSION=1.48.0
 DOCKER_TAG=$(shell git describe --tags)
 DOCKER_TEMPLATES:=$(wildcard *.Dockerfile.template)
 DOCKER_FILES=$(DOCKER_TEMPLATES:%.template=%)

--- a/alpine-debug.Dockerfile.template
+++ b/alpine-debug.Dockerfile.template
@@ -13,7 +13,7 @@ FROM alpine:latest
 # for devel only
 RUN apk add lftp
 RUN apk add --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing curlftpfs
-RUN apk add --repository http://dl-cdn.alpinelinux.org/alpine/edge/main fuse
+RUN apk add --repository http://dl-cdn.alpinelinux.org/alpine/edge/main fuse curl
 
 # we could also RUN 'apk add ca-certificates', but we prefer to be consistent with the -minimal image
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt

--- a/src/args.rs
+++ b/src/args.rs
@@ -17,6 +17,7 @@ pub const FTPS_REQUIRED_ON_DATA_CHANNEL: &str = "ftps-required-on-data-channel";
 pub const GCS_BASE_URL: &str = "sbe-gcs-base-url";
 pub const GCS_BUCKET: &str = "sbe-gcs-bucket";
 pub const GCS_KEY_FILE: &str = "sbe-gcs-key-file";
+pub const GCS_SERVICE_ACCOUNT: &str = "sbe-gcs-service-account";
 pub const HTTP_BIND_ADDRESS: &str = "bind-address-http";
 pub const IDLE_SESSION_TIMEOUT: &str = "idle-session-timeout";
 pub const INSTANCE_NAME: &str = "instance-name";
@@ -320,6 +321,14 @@ pub(crate) fn clap_app(tmp_dir: &str) -> clap::App {
                 .value_name("KEY_FILE")
                 .help("The JSON file that contains the service account key for access to Google Cloud Storage.")
                 .env("UNFTP_SBE_GCS_KEY_FILE")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name(GCS_SERVICE_ACCOUNT)
+                .long("sbe-gcs-service-account")
+                .value_name("SERVICE_ACCOUNT_NAME")
+                .help("The name of the service account to use when authenticating using GKE workload identity.")
+                .env("UNFTP_SBE_GCS_SERVICE_ACCOUNT")
                 .takes_value(true),
         )
         .arg(


### PR DESCRIPTION
Ability to use the new support for GKE workload identity added to libunftp. See: 

- https://github.com/bolcom/libunftp/issues/298
- https://github.com/bolcom/libunftp/pull/303

This PR adds the `--sbe-gcs-service-account` command line option and the `UNFTP_SBE_GCS_SERVICE_ACCOUNT` environment variable option that will, if specified, use the specific service account when doing authentication using 
GKE workload identity. The `--sbe-gcs-key-file` option is no longer required when `--sbe-type` is 'gcs'. Specifying both `--sbe-gcs-key-file` and `--sbe-gcs-service-account` is an error and omitting both wil activate workload identity authentication using the default service account.

