### PR TITLE
Added --sbe-gcs-root argument

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,11 +512,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84129d298a6d57d246960ff8eb831ca4af3f96d29e2e28848dae275408658e26"
+checksum = "7245cd7449cc792608c3c8a9eaf69bd4eabbabf802713748fd739c98b82f0747"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.0",
  "fnv",
  "itoa",
 ]
@@ -700,7 +700,7 @@ dependencies = [
 [[package]]
 name = "libunftp"
 version = "0.15.0"
-source = "git+https://github.com/bolcom/libunftp.git?rev=293a8e7dc8741f372b27ee191cbda1eecc32f185#293a8e7dc8741f372b27ee191cbda1eecc32f185"
+source = "git+https://github.com/bolcom/libunftp.git?rev=5dfabf30edbda36a88d3ab1c3692687332986d1e#5dfabf30edbda36a88d3ab1c3692687332986d1e"
 dependencies = [
  "async-trait",
  "bytes 0.5.6",
@@ -1122,11 +1122,11 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d70cf4412832bcac9cffe27906f4a66e450d323525e977168c70d1b36120ae"
+checksum = "c8425533e7122f0c3cc7a37e6244b16ad3a2cc32ae7ac6276e2a75da0d9c200d"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "fnv",
  "lazy_static",
  "parking_lot 0.11.0",
@@ -1515,9 +1515,9 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "slog"
-version = "2.5.2"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cc9c640a4adbfbcc11ffb95efe5aa7af7309e002adab54b185507dbf2377b99"
+checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
 
 [[package]]
 name = "slog-async"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,12 +30,12 @@ version="0.1.0"
 async-trait = "0.1.41"
 clap = "2.33.3"
 futures = "0.3.9"
-http = "0.2.2"
+http = "0.2.3"
 hyper = { version = "0.14.1", features = ["server", "http1"] }
 lazy_static = "1.4.0"
-libunftp = { git = "https://github.com/bolcom/libunftp.git", rev="293a8e7dc8741f372b27ee191cbda1eecc32f185" }
-prometheus = "0.10.0"
-slog = { version = "2.5.2", features = ["max_level_trace", "release_max_level_info"] }
+libunftp = { git = "https://github.com/bolcom/libunftp.git", rev="5dfabf30edbda36a88d3ab1c3692687332986d1e" }
+prometheus = "0.11.0"
+slog = { version = "2.7.0", features = ["max_level_trace", "release_max_level_info"] }
 slog-async = "2.5.0"
 slog-term = "2.6.0"
 tokio = { version = "1.0.1", features = ["full"] }

--- a/src/args.rs
+++ b/src/args.rs
@@ -17,6 +17,7 @@ pub const FTPS_REQUIRED_ON_DATA_CHANNEL: &str = "ftps-required-on-data-channel";
 pub const GCS_BASE_URL: &str = "sbe-gcs-base-url";
 pub const GCS_BUCKET: &str = "sbe-gcs-bucket";
 pub const GCS_KEY_FILE: &str = "sbe-gcs-key-file";
+pub const GCS_ROOT: &str = "sbe-gcs-root";
 pub const GCS_SERVICE_ACCOUNT: &str = "sbe-gcs-service-account";
 pub const HTTP_BIND_ADDRESS: &str = "bind-address-http";
 pub const IDLE_SESSION_TIMEOUT: &str = "idle-session-timeout";
@@ -321,6 +322,15 @@ pub(crate) fn clap_app(tmp_dir: &str) -> clap::App {
                 .value_name("KEY_FILE")
                 .help("The JSON file that contains the service account key for access to Google Cloud Storage.")
                 .env("UNFTP_SBE_GCS_KEY_FILE")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name(GCS_ROOT)
+                .long("sbe-gcs-root")
+                .value_name("PATH")
+                .help("The root path in the bucket where unFTP will look for and store files.")
+                .env("UNFTP_SBE_GCS_ROOT")
+                .default_value("/unftp")
                 .takes_value(true),
         )
         .arg(

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,6 +152,10 @@ fn gcs_storage_backend(
         .value_of(args::GCS_BASE_URL)
         .ok_or_else(|| format!("--{} is required when using storage type gcs", args::GCS_BUCKET))?
         .into();
+    let root_dir: PathBuf = m
+        .value_of(args::GCS_ROOT)
+        .ok_or_else(|| format!("--{} is required when using storage type gcs", args::GCS_ROOT))?
+        .into();
     let auth_method: AuthMethod = match (m.value_of(args::GCS_SERVICE_ACCOUNT), m.value_of(args::GCS_KEY_FILE)) {
         (None, None) => AuthMethod::WorkloadIdentity(None),
         (Some(_), Some(_)) => {
@@ -175,6 +179,7 @@ fn gcs_storage_backend(
         inner: storage::InnerStorage::Cloud(libunftp::storage::cloud_storage::CloudStorage::new(
             base_url.clone(),
             bucket.clone(),
+            root_dir.clone(),
             auth_method.clone(),
         )),
         log: sub_log.clone(),


### PR DESCRIPTION
This PR allows the unFTP user to specify the root directory in the bucket where the Cloud Storage Back-end will look for and put its files.