### PR TITLE
Implement per-user home directories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,9 +692,9 @@ checksum = "05842d0d43232b23ccb7060ecb0f0626922c21f30012e97b767b30afd4a5d4b9"
 
 [[package]]
 name = "hyper"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e5f105c494081baa3bf9e200b279e27ec1623895cd504c7dbef8d0b080fcf54"
+checksum = "07d6baa1b441335f3ce5098ac421fb6547c46dda735ca1bc6d0153c838f9dd83"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -706,7 +706,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project",
+ "pin-project-lite",
  "socket2",
  "tokio",
  "tower-service",
@@ -1843,9 +1843,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.6.1"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a38d31d7831c6ed7aad00aa4c12d9375fd225a6dd77da1d25b707346319a975"
+checksum = "5fb2ed024293bb19f7a5dc54fe83bf86532a44c12a2bb8ba40d64a4509395ca2"
 dependencies = [
  "autocfg",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,6 +34,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,7 +216,7 @@ version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
- "ansi_term",
+ "ansi_term 0.11.0",
  "atty",
  "bitflags",
  "strsim",
@@ -408,6 +417,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 
 [[package]]
 name = "digest"
@@ -1042,6 +1057,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
+name = "output_vt100"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "pam"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1156,6 +1180,18 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "pretty_assertions"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cab0e7c02cf376875e9335e0ba1da535775beb5450d21e1dffca068818ed98b"
+dependencies = [
+ "ansi_term 0.12.1",
+ "ctor",
+ "diff",
+ "output_vt100",
+]
 
 [[package]]
 name = "proc-macro-hack"
@@ -1999,6 +2035,7 @@ dependencies = [
  "hyper",
  "lazy_static",
  "libunftp",
+ "pretty_assertions",
  "prometheus",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ bitflags = "1.0"
 clap = "2.33.3"
 futures = "0.3.15"
 http = "0.2.4"
-hyper = { version = "0.14.7", features = ["server", "http1"] }
+hyper = { version = "0.14.9", features = ["server", "http1"] }
 lazy_static = "1.4.0"
 libunftp = { git = "https://github.com/bolcom/libunftp.git", rev="44b8c8eebc43baadce3275cb890570bdca4b525e" }
 prometheus = { version = "0.12.0", features = ["process"] }
@@ -41,7 +41,7 @@ serde_json = { version = "1.0.64" }
 slog = { version = "2.7.0", features = ["max_level_trace", "release_max_level_info"] }
 slog-async = "2.6.0"
 slog-term = "2.8.0"
-tokio = { version = "1.5.0", features = ["full"] }
+tokio = { version = "1.7.1", features = ["full"] }
 unftp-sbe-fs = "0.1.1"
 unftp-sbe-gcs = { version = "0.1.1", optional = true }
 unftp-auth-rest = { git = "https://github.com/bolcom/libunftp.git", rev="44b8c8eebc43baadce3275cb890570bdca4b525e", version = "0.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,9 @@ musl = ["rest_auth", "cloud_storage", "jsonfile_auth"]
 # Features used in our docker builds
 docker = ["musl"]
 
+[dev-dependencies]
+pretty_assertions = "0.7.1"
+
 [build-dependencies]
 built = "0.3"
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -15,10 +15,10 @@ pub struct User {
     /// What FTP commands can the user perform
     pub vfs_permissions: VfsOperations,
     /// For some users we know they will only upload a certain type of file
-    pub allowed_mime_types: Option<Vec<String>>,
-    // Example of things we can extend with:
-    // Switch the on for users that we know can/will connect with FTPS
-    //pub enforce_tls: bool,
+    pub allowed_mime_types: Option<Vec<String>>, // TODO: Look at https://crates.io/crates/infer to do this
+                                                 // Example of things we can extend with:
+                                                 // Switch the on for users that we know can/will connect with FTPS
+                                                 //pub enforce_tls: bool,
 }
 
 impl User {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,5 +1,5 @@
-mod chooser;
+mod choose;
 mod restrict;
 
-pub use chooser::{InnerStorage, StorageBe};
+pub use choose::{ChoosingVfs, InnerVfs};
 pub use restrict::RestrictingVfs;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,5 +1,7 @@
 mod choose;
 mod restrict;
+mod rooter;
 
-pub use choose::{ChoosingVfs, InnerVfs};
+pub use choose::{ChoosingVfs, InnerVfs, SbeMeta};
 pub use restrict::RestrictingVfs;
+pub use rooter::{RooterVfs, UserWithRoot};

--- a/src/storage/restrict.rs
+++ b/src/storage/restrict.rs
@@ -8,13 +8,13 @@ use libunftp::storage::{Fileinfo, Metadata, StorageBackend};
 use tokio::io::AsyncRead;
 
 use crate::auth::{User, VfsOperations};
-use crate::storage::chooser::{SbeMeta, StorageBe};
+use crate::storage::choose::{ChoosingVfs, SbeMeta};
 
 /// A virtual filesystem that checks if the user has permissions to do its operations before it
 /// delegates to another storage back-end.
 #[derive(Debug)]
 pub struct RestrictingVfs {
-    pub delegate: StorageBe,
+    pub delegate: ChoosingVfs,
 }
 
 #[async_trait]

--- a/src/storage/rooter.rs
+++ b/src/storage/rooter.rs
@@ -1,0 +1,323 @@
+use async_trait::async_trait;
+use libunftp::{
+    auth::UserDetail,
+    storage::{Fileinfo, Metadata, Result, StorageBackend},
+};
+use std::borrow::Cow;
+use std::ffi::{OsStr, OsString};
+use std::fmt::Debug;
+use std::io::{Cursor, Error};
+use std::marker::PhantomData;
+use std::path::{Component, Path, PathBuf};
+use tokio::io::AsyncRead;
+
+/// Used by [RooterVfs] to obtain the user's root path from a [UserDetail](libunftp::auth::UserDetail) implementation
+pub trait UserWithRoot {
+    /// Returns the relative path to the user's root if it exists otherwise null.
+    fn user_root(&self) -> Option<PathBuf>;
+}
+
+/// A virtual file system for libunftp that wraps other file systems
+#[derive(Debug)]
+pub struct RooterVfs<Delegate, User, Meta>
+where
+    Delegate: StorageBackend<User>,
+    User: UserDetail + UserWithRoot,
+    Meta: Metadata + Debug + Sync + Send,
+{
+    inner: Delegate,
+    x: PhantomData<Meta>,
+    y: PhantomData<User>,
+}
+
+impl<Delegate, User, Meta> RooterVfs<Delegate, User, Meta>
+where
+    Delegate: StorageBackend<User>,
+    User: UserDetail + UserWithRoot,
+    Meta: Metadata + Debug + Sync + Send,
+{
+    pub fn new(inner: Delegate) -> Self {
+        RooterVfs {
+            inner,
+            x: PhantomData,
+            y: PhantomData,
+        }
+    }
+
+    pub(super) fn new_path<'a>(user: &Option<User>, requested_path: &'a Path) -> Cow<'a, Path> {
+        if let Some(u) = user {
+            if let Some(user_root) = u.user_root() {
+                Cow::Owned(Self::root_to(user_root.as_os_str(), requested_path).unwrap())
+            } else {
+                Cow::Borrowed(requested_path)
+            }
+        } else {
+            Cow::Borrowed(requested_path)
+        }
+    }
+
+    fn root_to(root: &OsStr, requested_path: &Path) -> std::result::Result<PathBuf, ()> {
+        let mut iter = requested_path.components();
+
+        if let Some(first_component) = iter.next() {
+            let mut tokens = Vec::new();
+
+            match first_component {
+                Component::RootDir | Component::ParentDir => {
+                    tokens.push(root);
+                }
+                Component::CurDir => {
+                    return Err(()); // It should never start with .
+                }
+                _ => {
+                    tokens.push(root);
+                    tokens.push(first_component.as_os_str());
+                }
+            }
+
+            for component in iter {
+                match component {
+                    Component::CurDir => {}
+                    Component::ParentDir => {
+                        let tokens_length = tokens.len();
+                        if tokens_length > 1 {
+                            tokens.remove(tokens_length - 1);
+                        }
+                    }
+                    _ => {
+                        tokens.push(component.as_os_str());
+                    }
+                }
+            }
+
+            let tokens_length = tokens.len();
+
+            let size = tokens.iter().fold(tokens_length - 1, |acc, &x| acc + x.len()) - 1;
+
+            let mut path_string = OsString::with_capacity(size);
+
+            for token in tokens.iter().take(tokens_length - 1) {
+                path_string.push(token);
+                path_string.push("/");
+            }
+
+            path_string.push(tokens[tokens_length - 1]);
+
+            let path_buf = PathBuf::from(path_string);
+
+            Ok(path_buf)
+        } else {
+            Err(()) // There will always be a prefix
+        }
+    }
+}
+
+#[async_trait]
+impl<Delegate, User, Meta> StorageBackend<User> for RooterVfs<Delegate, User, Meta>
+where
+    Delegate: StorageBackend<User>,
+    User: UserDetail + UserWithRoot,
+    Meta: Metadata + Debug + Sync + Send,
+{
+    type Metadata = Delegate::Metadata;
+
+    async fn metadata<P: AsRef<Path> + Send + Debug>(&self, user: &Option<User>, path: P) -> Result<Self::Metadata> {
+        let path = Self::new_path(user, path.as_ref());
+        self.inner.metadata(user, path).await
+    }
+
+    async fn md5<P: AsRef<Path> + Send + Debug>(&self, user: &Option<User>, path: P) -> Result<String>
+    where
+        P: AsRef<Path> + Send + Debug,
+    {
+        let path = Self::new_path(user, path.as_ref());
+        self.inner.md5(user, path).await
+    }
+
+    async fn list<P: AsRef<Path> + Send + Debug>(
+        &self,
+        user: &Option<User>,
+        path: P,
+    ) -> Result<Vec<Fileinfo<PathBuf, Self::Metadata>>>
+    where
+        <Self as StorageBackend<User>>::Metadata: Metadata,
+    {
+        let path = Self::new_path(user, path.as_ref());
+        self.inner.list(user, path).await
+    }
+
+    async fn list_fmt<P>(&self, user: &Option<User>, path: P) -> Result<Cursor<Vec<u8>>>
+    where
+        P: AsRef<Path> + Send + Debug,
+        Self::Metadata: Metadata + 'static,
+    {
+        let path = Self::new_path(user, path.as_ref());
+        self.inner.list_fmt(user, path).await
+    }
+
+    async fn nlst<P>(&self, user: &Option<User>, path: P) -> std::result::Result<Cursor<Vec<u8>>, Error>
+    where
+        P: AsRef<Path> + Send + Debug,
+        Self::Metadata: Metadata + 'static,
+    {
+        let path = Self::new_path(user, path.as_ref());
+        self.inner.nlst(user, path).await
+    }
+
+    async fn get_into<'a, P, W: ?Sized>(
+        &self,
+        user: &Option<User>,
+        path: P,
+        start_pos: u64,
+        output: &'a mut W,
+    ) -> Result<u64>
+    where
+        W: tokio::io::AsyncWrite + Unpin + Sync + Send,
+        P: AsRef<Path> + Send + Debug,
+    {
+        let path = Self::new_path(user, path.as_ref());
+        self.inner.get_into(user, path, start_pos, output).await
+    }
+
+    async fn get<P: AsRef<Path> + Send + Debug>(
+        &self,
+        user: &Option<User>,
+        path: P,
+        start_pos: u64,
+    ) -> Result<Box<dyn AsyncRead + Send + Sync + Unpin>> {
+        let path = Self::new_path(user, path.as_ref());
+        self.inner.get(user, path, start_pos).await
+    }
+
+    async fn put<P: AsRef<Path> + Send + Debug, R: tokio::io::AsyncRead + Send + Sync + Unpin + 'static>(
+        &self,
+        user: &Option<User>,
+        input: R,
+        path: P,
+        start_pos: u64,
+    ) -> Result<u64> {
+        let path = Self::new_path(user, path.as_ref());
+        self.inner.put(user, input, path, start_pos).await
+    }
+
+    async fn del<P: AsRef<Path> + Send + Debug>(&self, user: &Option<User>, path: P) -> Result<()> {
+        let path = Self::new_path(user, path.as_ref());
+        self.inner.del(user, path).await
+    }
+
+    async fn mkd<P: AsRef<Path> + Send + Debug>(&self, user: &Option<User>, path: P) -> Result<()> {
+        let path = Self::new_path(user, path.as_ref());
+        self.inner.mkd(user, path).await
+    }
+
+    async fn rename<P: AsRef<Path> + Send + Debug>(&self, user: &Option<User>, from: P, to: P) -> Result<()> {
+        let from = Self::new_path(user, from.as_ref());
+        let to = Self::new_path(user, to.as_ref());
+        self.inner.rename(user, from, to).await
+    }
+
+    async fn rmd<P: AsRef<Path> + Send + Debug>(&self, user: &Option<User>, path: P) -> Result<()> {
+        let path = Self::new_path(user, path.as_ref());
+        self.inner.rmd(user, path).await
+    }
+
+    async fn cwd<P: AsRef<Path> + Send + Debug>(&self, user: &Option<User>, path: P) -> Result<()> {
+        let path = Self::new_path(user, path.as_ref());
+        self.inner.cwd(user, path).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::auth::VfsOperations;
+    use pretty_assertions::assert_eq;
+    use std::path::{Path, PathBuf};
+
+    fn new_path(root: &str, requested: &str) -> PathBuf {
+        super::RooterVfs::<unftp_sbe_fs::Filesystem, crate::auth::User, unftp_sbe_fs::Meta>::new_path(
+            &Some(crate::auth::User {
+                username: "test".to_string(),
+                name: None,
+                surname: None,
+                account_enabled: false,
+                vfs_permissions: VfsOperations::all(),
+                allowed_mime_types: None,
+                root: Some(PathBuf::from(root)),
+            }),
+            Path::new(requested),
+        )
+        .into()
+    }
+
+    fn new_path_no_root(requested: &str) -> PathBuf {
+        super::RooterVfs::<unftp_sbe_fs::Filesystem, crate::auth::User, unftp_sbe_fs::Meta>::new_path(
+            &Some(crate::auth::User {
+                username: "test".to_string(),
+                name: None,
+                surname: None,
+                account_enabled: false,
+                vfs_permissions: VfsOperations::all(),
+                allowed_mime_types: None,
+                root: None,
+            }),
+            Path::new(requested),
+        )
+        .into()
+    }
+
+    #[test]
+    fn no_user_root_case() {
+        assert_eq!(
+            PathBuf::from("/my/documents/test.txt"),
+            new_path_no_root("/my/documents/test.txt")
+        );
+    }
+
+    #[test]
+    fn rooted_is_rerooted() {
+        assert_eq!(
+            PathBuf::from("alice/my/documents/test.txt"),
+            new_path("alice", "/my/documents/test.txt")
+        );
+    }
+
+    #[test]
+    fn relative_is_rooted() {
+        assert_eq!(
+            PathBuf::from("alice/my/documents/test.txt"),
+            new_path("alice", "my/documents/test.txt")
+        );
+    }
+
+    #[test]
+    fn cdups_is_ignored() {
+        assert_eq!(
+            PathBuf::from("alice/my/documents/test.txt"),
+            new_path("alice", "../../my/documents/test.txt")
+        );
+    }
+
+    #[test]
+    fn dots_removed_and_applied() {
+        assert_eq!(
+            PathBuf::from("alice/documents/test.txt"),
+            new_path("alice", "../../my/../.././documents/test.txt")
+        );
+    }
+
+    #[test]
+    fn user_root_with_trailing_slash() {
+        assert_eq!(
+            PathBuf::from("alice/documents/test.txt"),
+            new_path("alice/", "../../my/../.././documents/test.txt")
+        );
+    }
+
+    #[test]
+    fn user_root_with_slashed_in_front() {
+        assert_eq!(
+            PathBuf::from("/alice/documents/test.txt"),
+            new_path("/alice", "../../my/../.././documents/test.txt")
+        );
+    }
+}


### PR DESCRIPTION
This builds on github PR #97 to add a configurable optional home
directory per user as requested in issue #85.

The user's home gets specified in a JSON file pointed to by the
`--usr-json-path` argument. The `root` property needs to be set:

```json
[
  {
    "username": "alice",
    "password": "12345678",
    "root": "alice"
  },
  {
    "username": "bob",
    "password": "secret",
    "root": "bob"
  }
]
```

At the moment if the `root` is not specified then the user will gain
access to the root of the storage back-end.

This PR also includes some upgrades and other naming refactorings.