### PR TITLE
Include eventType attribute for pub/sub messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-RUST_VERSION=1.56.1
+RUST_VERSION=1.57.0
 DOCKER_TAG=$(shell git describe --tags)
 DOCKER_TEMPLATES:=$(wildcard *.Dockerfile.template)
 DOCKER_FILES=$(DOCKER_TEMPLATES:%.template=%)

--- a/crates/redislog/src/lib.rs
+++ b/crates/redislog/src/lib.rs
@@ -75,8 +75,6 @@ use slog::{OwnedKVList, Record, KV};
 /// [slog-url]: https://github.com/slog-rs/slog
 #[derive(Debug)]
 pub struct Logger {
-    redis_host: String,
-    redis_port: u32,
     redis_key: String,
     app_name: String,
     hostname: String,
@@ -196,8 +194,6 @@ impl Builder {
         redis::cmd("PING").query(&mut *con)?;
 
         Ok(Logger {
-            redis_host: self.redis_host,
-            redis_port: self.redis_port,
             redis_key: self.redis_key,
             app_name: self.app_name,
             hostname: self.hostname.unwrap_or_else(get_host_name),

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -134,6 +134,7 @@ struct UserJsonObj {
     name: Option<String>,
     surname: Option<String>,
     vfs_perms: Option<Vec<String>>,
+    #[allow(dead_code)]
     allowed_mime_types: Option<Vec<String>>,
     root: Option<String>,
     account_enabled: Option<bool>,

--- a/src/storage/choose.rs
+++ b/src/storage/choose.rs
@@ -20,6 +20,7 @@ pub struct ChoosingVfs {
 }
 
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum InnerVfs {
     Cloud(unftp_sbe_gcs::CloudStorage),
     File(unftp_sbe_fs::Filesystem),


### PR DESCRIPTION
Not all subscribers of a Pub/Sub topic will be interested in all
messages. For instance the unFTP inventory are only interested in Login
events.

Pub/Sub allows one to filter messages coming into a subscription by
using attribute filters. See
https://cloud.google.com/pubsub/docs/filtering

This commit adds the event type to all outgoing messages by populating
an attribute named `eventType` in the pub/sub messages.