### PR TITLE
Fix oversight in previous release

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -220,6 +220,7 @@ fn gcs_storage_backend(
             AuthMethod::ServiceAccountKey(service_account_key)
         }
     };
+    let instance_name = m.value_of(args::INSTANCE_NAME).unwrap().to_owned();
 
     slog::info!(log, "GCS back-end auth method: {}", auth_method);
 
@@ -238,8 +239,8 @@ fn gcs_storage_backend(
                 },
             }),
             event_dispatcher.clone(),
-            "xxx",
-            "yyy",
+            instance_name.clone(),
+            get_host_name(),
         )
     }))
 }


### PR DESCRIPTION
The instance name and event name for the pub/sub events were hardcoded
to xxx and yyy which makes it obvious to see that the feature was not
100% complete. This commit fixes that. Sorry...