### PR TITLE
Improve pub/sub integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,9 +43,9 @@ checksum = "d4d7d63395147b81a9e570bcc6243aaf71c017bd666d4909cfef0085bdda8d73"
 
 [[package]]
 name = "async-trait"
-version = "0.1.51"
+version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44318e776df68115a881de9a8fd1b9e53368d7a4a5ce4cc48517da3393233a5e"
+checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -83,9 +83,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+checksum = "f1d36a02058e76b040de25a4464ba1c80935655595b661505c8b39b664828b95"
 dependencies = [
  "generic-array",
 ]
@@ -241,9 +241,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils 0.8.5",
@@ -283,6 +283,15 @@ checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
  "cfg-if 1.0.0",
  "lazy_static",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d6b536309245c849479fba3da410962a43ed8e51c26b729208ec0ac2798d0"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -336,9 +345,9 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.16"
+version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40eebddd2156ce1bb37b20bbe5151340a31828b1f2d22ba4141f3531710e38df"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -355,10 +364,12 @@ checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 
 [[package]]
 name = "digest"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+checksum = "b697d66081d42af4fba142d56918a3cb21dc8eb63372c6b85d14f44fb9c5979b"
 dependencies = [
+ "block-buffer",
+ "crypto-common",
  "generic-array",
 ]
 
@@ -428,9 +439,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12aa0eb539080d55c3f2d45a67c3b58b6b0773c1a3ca2dfec66d58c97fd66ca"
+checksum = "28560757fe2bb34e79f907794bb6b22ae8b0e5c669b638a1132f2592b19035b4"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -443,9 +454,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
+checksum = "ba3dda0b6588335f360afc675d0564c17a77a2bda81ca178a4b6081bd86c7f0b"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -453,15 +464,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
+checksum = "d0c8ff0461b82559810cdccfde3215c3f373807f5e5232b71479bff7bb2583d7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45025be030969d763025784f7f355043dc6bc74093e4ecc5000ca4dc50d8745c"
+checksum = "29d6d2ff5bb10fb95c85b8ce46538a2e5f5e7fdc755623a7d4529ab8a4ed9d2a"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -470,18 +481,16 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
+checksum = "b1f9d34af5a1aac6fb380f735fe510746c38067c5bf16c7fd250280503c971b2"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
+checksum = "6dbd947adfffb0efc70599b3ddcf7b5597bb5fa9e245eb99f62b3a5f7bb8bd3c"
 dependencies = [
- "autocfg",
- "proc-macro-hack",
  "proc-macro2",
  "quote",
  "syn",
@@ -489,23 +498,22 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
+checksum = "e3055baccb68d74ff6480350f8d6eb8fcfa3aa11bdc1a1ae3afdd0514617d508"
 
 [[package]]
 name = "futures-task"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
+checksum = "6ee7c6485c30167ce4dfb83ac568a849fe53274c831081476ee13e0dce1aad72"
 
 [[package]]
 name = "futures-util"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
+checksum = "d9b5cf40b47a271f77a8b1bec03ca09044d99d2372c0de244e66430761127164"
 dependencies = [
- "autocfg",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -515,8 +523,6 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
  "slab",
 ]
 
@@ -562,9 +568,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "h2"
-version = "0.3.3"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825343c4eef0b63f541f8903f395dc5beb362a979b5799a84062527ef1e37726"
+checksum = "0c9de88456263e249e241fcd211d3954e2c9b0ef7ccfc235a444eb367cae3689"
 dependencies = [
  "bytes",
  "fnv",
@@ -602,13 +608,13 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
+checksum = "31f4c6746584866f0feabcc69893c5b51beef3831656a968ed7ae254cdc4fd03"
 dependencies = [
  "bytes",
  "fnv",
- "itoa",
+ "itoa 1.0.1",
 ]
 
 [[package]]
@@ -636,9 +642,9 @@ checksum = "05842d0d43232b23ccb7060ecb0f0626922c21f30012e97b767b30afd4a5d4b9"
 
 [[package]]
 name = "hyper"
-version = "0.14.15"
+version = "0.14.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436ec0091e4f20e655156a30a0df3770fe2900aa301e548e08446ec794b6953c"
+checksum = "b7ec3e62bdc98a2f0393a5048e4c30ef659440ea6e0e572965103e72bd836f55"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -649,7 +655,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa",
+ "itoa 0.4.7",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -669,10 +675,25 @@ dependencies = [
  "hyper",
  "log",
  "rustls 0.19.1",
- "rustls-native-certs",
+ "rustls-native-certs 0.5.0",
  "tokio",
  "tokio-rustls 0.22.0",
  "webpki 0.21.4",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
+dependencies = [
+ "http",
+ "hyper",
+ "log",
+ "rustls 0.20.2",
+ "rustls-native-certs 0.6.1",
+ "tokio",
+ "tokio-rustls 0.23.2",
 ]
 
 [[package]]
@@ -727,6 +748,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+
+[[package]]
 name = "jobserver"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -770,9 +797,9 @@ dependencies = [
 
 [[package]]
 name = "libunftp"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc17ea706d8085decd7cc7dfdc2ab1f64df57fc89f78ee08750feb4ee6dc77d"
+checksum = "4bb60d9f299b3ad35b051e9dead40f064c3d66eade41a41a1e3b78b85b2f997c"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -786,13 +813,13 @@ dependencies = [
  "moka",
  "prometheus",
  "proxy-protocol",
- "rustls 0.20.1",
+ "rustls 0.20.2",
  "rustls-pemfile",
  "slog",
  "slog-stdlog",
  "thiserror",
  "tokio",
- "tokio-rustls 0.23.1",
+ "tokio-rustls 0.23.2",
  "tokio-util",
  "tracing",
  "tracing-attributes",
@@ -853,13 +880,11 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "md-5"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
+checksum = "e6a38fc55c8bbc10058782919516f88826e70320db6d206aebc49611d24216ae"
 dependencies = [
- "block-buffer",
  "digest",
- "opaque-debug",
 ]
 
 [[package]]
@@ -923,11 +948,12 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.6.1"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0d5cf145315e1c07d9d67f07e12276902d86a952dac392cee7b895303b699d"
+checksum = "a00ecaecb5ad0d5f7c8ccd8eef26cb164941ebfa32dba5a5e4395a44dda096cc"
 dependencies = [
  "crossbeam-channel",
+ "crossbeam-utils 0.8.5",
  "moka-cht",
  "num_cpus",
  "once_cell",
@@ -935,6 +961,7 @@ dependencies = [
  "quanta",
  "scheduled-thread-pool",
  "skeptic",
+ "smallvec",
  "thiserror",
  "uuid",
 ]
@@ -1023,12 +1050,6 @@ name = "once_cell"
 version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl-probe"
@@ -1152,18 +1173,6 @@ dependencies = [
  "diff",
  "output_vt100",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
-name = "proc-macro-nested"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
@@ -1336,7 +1345,7 @@ dependencies = [
  "async-trait",
  "combine",
  "dtoa",
- "itoa",
+ "itoa 0.4.7",
  "percent-encoding",
  "sha1",
  "url",
@@ -1404,11 +1413,11 @@ dependencies = [
 
 [[package]]
 name = "rustc_version"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 0.11.0",
+ "semver 1.0.4",
 ]
 
 [[package]]
@@ -1435,9 +1444,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac4581f0fc0e0efd529d069e8189ec7b90b8e7680e21beb35141bdc45f36040"
+checksum = "d37e5e2290f3e040b594b1a9e04377c2c671f1a1cfd9bfdef82106ac1c113f84"
 dependencies = [
  "log",
  "ring",
@@ -1453,6 +1462,18 @@ checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
 dependencies = [
  "openssl-probe",
  "rustls 0.19.1",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca9ebdfa27d3fc180e42879037b5338ab1c040c06affd00d8338598e7800943"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
  "schannel",
  "security-framework",
 ]
@@ -1581,6 +1602,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+
+[[package]]
 name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1597,18 +1624,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.130"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.130"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
+checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1617,11 +1644,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.71"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063bf466a64011ac24040a49009724ee60a57da1b437617ceb32e53ad61bfb19"
+checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
 dependencies = [
- "itoa",
+ "itoa 1.0.1",
  "ryu",
  "serde",
 ]
@@ -1880,11 +1907,10 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e992e41e0d2fb9f755b37446f20900f64446ef54874f40a60c78f021ac6144"
+checksum = "fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838"
 dependencies = [
- "autocfg",
  "bytes",
  "libc",
  "memchr",
@@ -1900,9 +1926,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9efc1aba077437943f7515666aa2b882dfabfbfdf89c819ea75a8d6e9eaba5e"
+checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1922,11 +1948,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.23.1"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4baa378e417d780beff82bf54ceb0d195193ea6a00c14e22359e7f39456b5689"
+checksum = "a27d5f2b839802bd8267fa19b0530f5a08b9c08cd417976be2a65d130fe1c11b"
 dependencies = [
- "rustls 0.20.1",
+ "rustls 0.20.2",
  "tokio",
  "webpki 0.22.0",
 ]
@@ -2034,7 +2060,7 @@ dependencies = [
  "futures",
  "http",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.23.0",
  "lazy_static",
  "libunftp",
  "pretty_assertions",
@@ -2097,7 +2123,7 @@ checksum = "f4325ad9acc1cd864d05628f0dd5d5abd9954501155dbccbd82c55cc00bc63cc"
 dependencies = [
  "async-trait",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.22.1",
  "libunftp",
  "percent-encoding",
  "regex",
@@ -2136,7 +2162,7 @@ dependencies = [
  "chrono",
  "futures",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.22.1",
  "libunftp",
  "mime",
  "percent-encoding",
@@ -2419,7 +2445,7 @@ dependencies = [
  "futures",
  "http",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.22.1",
  "log",
  "percent-encoding",
  "rustls 0.19.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,31 +27,31 @@ path="crates/redislog"
 version="0.1.2"
 
 [dependencies]
-async-trait = "0.1.51"
+async-trait = "0.1.52"
 base64 = "0.13.0"
 bitflags = "1.3.2"
 clap = "2.33.3"
-futures = "0.3.17"
-http = "0.2.5"
-hyper = { version = "0.14.15", features = ["server", "http1"] }
-hyper-rustls = "^0.22"
+futures = "0.3.19"
+http = "0.2.6"
+hyper = { version = "0.14.16", features = ["server", "http1"] }
+hyper-rustls = "0.23.0"
 lazy_static = "1.4.0"
-libunftp = "0.18.2"
+libunftp = "0.18.3"
 prometheus = { version = "0.13.0", features = ["process"] }
-serde = { version = "1.0.130", features = ["derive"] }
-serde_json = { version = "1.0.71" }
+serde = { version = "1.0.133", features = ["derive"] }
+serde_json = { version = "1.0.74" }
 slog = { version = "2.7.0", features = ["max_level_trace", "release_max_level_info"] }
 slog-async = "2.7.0"
 slog-term = "2.8.0"
 thiserror = "1.0.30"
-tokio = { version = "1.14.0", features = ["full"] }
+tokio = { version = "1.15.0", features = ["full"] }
 unftp-sbe-fs = "0.2.0"
 unftp-sbe-gcs = { version = "0.2.0", optional = true }
 unftp-auth-rest = { version = "0.2.0", optional = true }
 unftp-auth-jsonfile = { version = "0.2.0", optional = true }
 
 # Purely to resolve conflicts
-tracing="0.1.28"
+tracing="0.1.29"
 
 [target.'cfg(unix)'.dependencies]
 unftp-auth-pam = { version = "0.2.0", optional = true }

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-RUST_VERSION=1.57.0
+RUST_VERSION=1.58.0
 DOCKER_TAG=$(shell git describe --tags)
 DOCKER_TEMPLATES:=$(wildcard *.Dockerfile.template)
 DOCKER_FILES=$(DOCKER_TEMPLATES:%.template=%)

--- a/build.rs
+++ b/build.rs
@@ -9,8 +9,8 @@ fn main() {
     println!("cargo:rustc-env=BUILD_VERSION={}", version);
 
     println!(
-        "cargo:rustc-env=PROJ_WEB_DIR={}",
-        format!("{}/{}", std::env::var("CARGO_MANIFEST_DIR").unwrap(), "web")
+        "cargo:rustc-env=PROJ_WEB_DIR={}/web",
+        std::env::var("CARGO_MANIFEST_DIR").unwrap(),
     );
 
     // Didn't quite get that to work yet.

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -15,6 +15,9 @@ pub struct NullEventDispatcher {}
 #[async_trait]
 impl EventDispatcher<FTPEvent> for NullEventDispatcher {
     async fn dispatch(&self, _event: FTPEvent) {
+        // let json = serde_json::to_string(&_event).unwrap();
+        // println!("\nDOOOOOOO : {}\n", json);
+        //
         // Do Nothing
     }
 }
@@ -25,6 +28,15 @@ pub struct FTPEvent {
     pub source_instance: String,
     pub hostname: String,
     pub payload: FTPEventPayload,
+    /// The user this event pertains to. A user may have more than one connection or session.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub username: Option<String>,
+    /// Identifies a single session pertaining to a connected client.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trace_id: Option<String>,
+    /// The event sequence number as incremented per session.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sequence_number: Option<u64>,
 }
 
 // The event variant
@@ -34,9 +46,8 @@ pub enum FTPEventPayload {
         libunftp_version: String,
         unftp_version: String,
     },
-    Login {
-        username: String,
-    },
+    Login,
+    Logout,
     Get {
         path: String,
     },

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -1,17 +1,13 @@
-use crate::auth::User;
-use crate::domain::{EventDispatcher, FTPEvent, FTPEventPayload, NullEventDispatcher};
-use crate::infra::PubsubEventDispatcher;
-use crate::{args, auth};
+use crate::{
+    args,
+    domain::{EventDispatcher, FTPEvent, FTPEventPayload, NullEventDispatcher},
+    infra::PubsubEventDispatcher,
+};
+
 use async_trait::async_trait;
 use clap::ArgMatches;
-use libunftp::auth::{AuthenticationError, Credentials, UserDetail};
-use libunftp::storage::{Fileinfo, Metadata, StorageBackend};
-use std::fmt::Debug;
-use std::io::Cursor;
-use std::marker::PhantomData;
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
-use tokio::io::{AsyncRead, AsyncWrite};
+use libunftp::notification::{DataEvent, EventMeta, PresenceEvent};
+use std::{fmt::Debug, sync::Arc};
 
 pub fn create_event_dispatcher(
     log: Arc<slog::Logger>,
@@ -42,260 +38,56 @@ pub fn create_event_dispatcher(
     }
 }
 
-/// A libunftp authenticator that will send pub/sub notifications if someone logs in.
 #[derive(Debug)]
-pub struct NotifyingAuthenticator {
-    inner: Box<dyn libunftp::auth::Authenticator<auth::User>>,
-    event_dispatcher: Arc<dyn EventDispatcher<FTPEvent>>,
-    instance_name: String,
-    hostname: String,
+pub struct FTPListener {
+    pub event_dispatcher: Arc<dyn EventDispatcher<FTPEvent>>,
+    pub instance_name: String,
+    pub hostname: String,
 }
 
-impl NotifyingAuthenticator {
-    pub fn new<Str>(
-        inner: Box<dyn libunftp::auth::Authenticator<auth::User>>,
-        event_dispatcher: Arc<dyn EventDispatcher<FTPEvent>>,
-        instance_name: Str,
-        hostname: Str,
-    ) -> Self
-    where
-        Str: Into<String>,
-    {
-        NotifyingAuthenticator {
-            inner,
-            event_dispatcher,
-            instance_name: instance_name.into(),
-            hostname: hostname.into(),
-        }
-    }
-}
-
-#[async_trait]
-impl libunftp::auth::Authenticator<auth::User> for NotifyingAuthenticator {
-    async fn authenticate(&self, username: &str, creds: &Credentials) -> Result<User, AuthenticationError> {
-        let user = self.inner.authenticate(username, creds).await?;
-        self.event_dispatcher
-            .dispatch(FTPEvent {
-                source_instance: self.instance_name.clone(),
-                hostname: self.hostname.clone(),
-                payload: FTPEventPayload::Login {
-                    username: username.to_string(),
-                },
-            })
-            .await;
-
-        Ok(user)
-    }
-
-    async fn cert_auth_sufficient(&self, username: &str) -> bool {
-        self.inner.cert_auth_sufficient(username).await
-    }
-}
-
-#[derive(Debug)]
-pub struct NotifyingStorageBackend<Delegate, User>
-where
-    Delegate: StorageBackend<User>,
-    User: UserDetail,
-{
-    inner: Delegate,
-    event_dispatcher: Arc<dyn EventDispatcher<FTPEvent>>,
-    instance_name: String,
-    hostname: String,
-    x: PhantomData<User>,
-}
-
-impl<Delegate, User> NotifyingStorageBackend<Delegate, User>
-where
-    Delegate: StorageBackend<User>,
-    User: UserDetail,
-{
-    pub fn new<Str>(
-        inner: Delegate,
-        event_dispatcher: Arc<dyn EventDispatcher<FTPEvent>>,
-        instance_name: Str,
-        hostname: Str,
-    ) -> Self
-    where
-        Str: Into<String>,
-    {
-        NotifyingStorageBackend {
-            inner,
-            event_dispatcher,
-            instance_name: instance_name.into(),
-            hostname: hostname.into(),
-            x: PhantomData,
-        }
-    }
-
-    async fn dispatch(&self, payload: FTPEventPayload) {
+impl FTPListener {
+    async fn dispatch(&self, payload: FTPEventPayload, m: EventMeta) {
         self.event_dispatcher
             .dispatch(FTPEvent {
                 source_instance: self.instance_name.clone(),
                 hostname: self.hostname.clone(),
                 payload,
+                username: Some(m.username),
+                trace_id: Some(m.trace_id),
+                sequence_number: Some(m.sequence_number),
             })
             .await
     }
 }
 
 #[async_trait]
-impl<Delegate, User> StorageBackend<User> for NotifyingStorageBackend<Delegate, User>
-where
-    Delegate: StorageBackend<User>,
-    Delegate::Metadata: Send + Sync + Debug,
-    User: UserDetail,
-{
-    type Metadata = Delegate::Metadata;
-
-    fn name(&self) -> &str {
-        self.inner.name()
+impl libunftp::notification::DataListener for FTPListener {
+    async fn receive_data_event(&self, e: DataEvent, m: EventMeta) {
+        let payload = match e {
+            DataEvent::Got { path, .. } => FTPEventPayload::Get { path },
+            DataEvent::Put { path, .. } => FTPEventPayload::Put { path },
+            DataEvent::Deleted { path } => FTPEventPayload::Delete { path },
+            DataEvent::MadeDir { path } => FTPEventPayload::MakeDir { path },
+            DataEvent::Renamed { from, to } => FTPEventPayload::Rename { from, to },
+            DataEvent::RemovedDir { path } => FTPEventPayload::RemoveDir { path },
+        };
+        self.dispatch(payload, m).await;
     }
+}
 
-    fn supported_features(&self) -> u32 {
-        self.inner.supported_features()
-    }
-
-    async fn metadata<P: AsRef<Path> + Send + Debug>(
-        &self,
-        user: &User,
-        path: P,
-    ) -> libunftp::storage::Result<Self::Metadata> {
-        self.inner.metadata(user, path).await
-    }
-
-    async fn md5<P: AsRef<Path> + Send + Debug>(&self, user: &User, path: P) -> libunftp::storage::Result<String>
-    where
-        P: AsRef<Path> + Send + Debug,
-    {
-        self.inner.md5(user, path).await
-    }
-
-    async fn list<P: AsRef<Path> + Send + Debug>(
-        &self,
-        user: &User,
-        path: P,
-    ) -> libunftp::storage::Result<Vec<Fileinfo<PathBuf, Self::Metadata>>>
-    where
-        <Self as StorageBackend<User>>::Metadata: Metadata,
-    {
-        self.inner.list(user, path).await
-    }
-
-    async fn list_fmt<P>(&self, user: &User, path: P) -> libunftp::storage::Result<Cursor<Vec<u8>>>
-    where
-        P: AsRef<Path> + Send + Debug,
-        Self::Metadata: Metadata + 'static,
-    {
-        self.inner.list_fmt(user, path).await
-    }
-
-    async fn list_vec<P>(&self, user: &User, path: P) -> libunftp::storage::Result<Vec<String>>
-    where
-        P: AsRef<Path> + Send + Debug,
-        Self::Metadata: Metadata + 'static,
-    {
-        self.inner.list_vec(user, path).await
-    }
-
-    async fn nlst<P>(&self, user: &User, path: P) -> Result<Cursor<Vec<u8>>, std::io::Error>
-    where
-        P: AsRef<Path> + Send + Debug,
-        Self::Metadata: Metadata + 'static,
-    {
-        self.inner.nlst(user, path).await
-    }
-
-    async fn get_into<'a, P, W: ?Sized>(
-        &self,
-        user: &User,
-        path: P,
-        start_pos: u64,
-        output: &'a mut W,
-    ) -> libunftp::storage::Result<u64>
-    where
-        W: AsyncWrite + Unpin + Sync + Send,
-        P: AsRef<Path> + Send + Debug,
-    {
-        let path_str = path.as_ref().to_string_lossy().to_string();
-        let result = self.inner.get_into(user, path, start_pos, output).await;
-        if result.is_ok() {
-            self.dispatch(FTPEventPayload::Get { path: path_str }).await;
+#[async_trait]
+impl libunftp::notification::PresenceListener for FTPListener {
+    async fn receive_presence_event(&self, e: PresenceEvent, m: EventMeta) {
+        if m.username.eq("unknown") {
+            // This is to prevent lots of LoggedOut events due to the unFTP health check
+            // that does a NgsOP and then a Quit but never logs in. In this case libunftp sets the
+            // username to unknown.
+            return;
         }
-        result
-    }
-
-    async fn get<P: AsRef<Path> + Send + Debug>(
-        &self,
-        user: &User,
-        path: P,
-        start_pos: u64,
-    ) -> libunftp::storage::Result<Box<dyn AsyncRead + Send + Sync + Unpin>> {
-        self.inner.get(user, path, start_pos).await
-    }
-
-    async fn put<P: AsRef<Path> + Send + Debug, R: AsyncRead + Send + Sync + Unpin + 'static>(
-        &self,
-        user: &User,
-        input: R,
-        path: P,
-        start_pos: u64,
-    ) -> libunftp::storage::Result<u64> {
-        let path_str = path.as_ref().to_string_lossy().to_string();
-        let result = self.inner.put(user, input, path, start_pos).await;
-        if result.is_ok() {
-            self.dispatch(FTPEventPayload::Put { path: path_str }).await;
-        }
-        result
-    }
-
-    async fn del<P: AsRef<Path> + Send + Debug>(&self, user: &User, path: P) -> libunftp::storage::Result<()> {
-        let path_str = path.as_ref().to_string_lossy().to_string();
-        let result = self.inner.del(user, path).await;
-        if result.is_ok() {
-            self.dispatch(FTPEventPayload::Delete { path: path_str }).await;
-        }
-        result
-    }
-
-    async fn mkd<P: AsRef<Path> + Send + Debug>(&self, user: &User, path: P) -> libunftp::storage::Result<()> {
-        let path_str = path.as_ref().to_string_lossy().to_string();
-        let result = self.inner.mkd(user, path).await;
-        if result.is_ok() {
-            self.dispatch(FTPEventPayload::MakeDir { path: path_str }).await;
-        }
-        result
-    }
-
-    async fn rename<P: AsRef<Path> + Send + Debug>(
-        &self,
-        user: &User,
-        from: P,
-        to: P,
-    ) -> libunftp::storage::Result<()> {
-        let from_str = from.as_ref().to_string_lossy().to_string();
-        let to_str = from.as_ref().to_string_lossy().to_string();
-        let result = self.inner.rename(user, from, to).await;
-        if result.is_ok() {
-            self.dispatch(FTPEventPayload::Rename {
-                from: from_str,
-                to: to_str,
-            })
-            .await;
-        }
-        result
-    }
-
-    async fn rmd<P: AsRef<Path> + Send + Debug>(&self, user: &User, path: P) -> libunftp::storage::Result<()> {
-        let path_str = path.as_ref().to_string_lossy().to_string();
-        let result = self.inner.rmd(user, path).await;
-        if result.is_ok() {
-            self.dispatch(FTPEventPayload::RemoveDir { path: path_str }).await;
-        }
-        result
-    }
-
-    async fn cwd<P: AsRef<Path> + Send + Debug>(&self, user: &User, path: P) -> libunftp::storage::Result<()> {
-        self.inner.cwd(user, path).await
+        let payload = match e {
+            PresenceEvent::LoggedIn => FTPEventPayload::Login,
+            PresenceEvent::LoggedOut => FTPEventPayload::Logout,
+        };
+        self.dispatch(payload, m).await;
     }
 }


### PR DESCRIPTION
- Added logout event                                                        
- Added username, trace_id and sequence number to events                    
- BREAKING change to login event. It no longer contains the username        
  inseide the login object.                                                 
- Now using the new libunftp notify and notify_data APIs instead of the  
  delegate authenticator / delegate storage back-end pattern                
 