### PR TITLE
Remove unneded tokio features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2307,7 +2307,6 @@ dependencies = [
  "mio",
  "num_cpus",
  "once_cell",
- "parking_lot 0.12.0",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ slog = { version = "2.7.0", features = ["max_level_trace", "release_max_level_in
 slog-async = "2.7.0"
 slog-term = "2.9.0"
 thiserror = "1.0.31"
-tokio = { version = "1.20.1", features = ["full"] }
+tokio = { version = "1.20.1", features = ["signal", "rt-multi-thread"] }
 unftp-sbe-fs = "0.2.1"
 unftp-sbe-gcs = { version = "0.2.1", optional = true }
 unftp-auth-rest = { version = "0.2.1", optional = true }


### PR DESCRIPTION
This commit updates Cargo manifest to explicitly utilize the Tokio features that are needed.

Closes #35
