### PR TITLE
Fix Windows build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -136,7 +136,6 @@ jobs:
         with:
           name: Windows
           path: target/x86_64-pc-windows-msvc/release/unftp.exe
-    continue-on-error: true # Until we fix the Windows issue. See https://github.com/bolcom/unFTP/issues/86
   
   build-macos-intel:
     runs-on: macos-latest


### PR DESCRIPTION
This fixes building on Windows by putting the unix specific signal handling behind a cfg attribute and adding Windows specific handling too.