### PR TITLE
Fix Rustsec 2020 0071

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -891,9 +891,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "hex"
@@ -1051,7 +1051,7 @@ version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi 0.3.2",
  "libc",
  "windows-sys 0.48.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,7 +57,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time 0.3.21",
+ "time",
 ]
 
 [[package]]
@@ -284,11 +284,8 @@ checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "time 0.1.45",
- "wasm-bindgen",
  "winapi",
 ]
 
@@ -2175,7 +2172,7 @@ dependencies = [
  "slog",
  "term",
  "thread_local",
- "time 0.3.21",
+ "time",
 ]
 
 [[package]]
@@ -2362,17 +2359,6 @@ checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if",
  "once_cell",
-]
-
-[[package]]
-name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
 ]
 
 [[package]]
@@ -2754,7 +2740,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_json",
- "time 0.3.21",
+ "time",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -3173,7 +3159,7 @@ dependencies = [
  "oid-registry",
  "rusticata-macros",
  "thiserror",
- "time 0.3.21",
+ "time",
 ]
 
 [[package]]
@@ -3203,7 +3189,7 @@ dependencies = [
  "seahash",
  "serde",
  "serde_json",
- "time 0.3.21",
+ "time",
  "tokio",
  "tower-service",
  "url",

--- a/crates/redislog/Cargo.toml
+++ b/crates/redislog/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/bolcom/unFTP/tree/master/crates/redislog"
 readme = "README.md"
 
 [dependencies]
-chrono = "0.4.26"
+chrono = { version = "0.4.26", default-features = false, features = ["std", "clock"] }
 r2d2 = "0.8.10"
 r2d2_redis = "0.14.0"
 redis = "0.20.2"


### PR DESCRIPTION
By eliminating a transitive dependency on time-0.1.45.  This should help compilation time, too.

Also, update the hermit-abi dependency. 0.3.1 was yanked for some reason.