### PR TITLE
fix: unftp command in docs had incorrect escaping

### DIFF
--- a/docs/server/starting.md
+++ b/docs/server/starting.md
@@ -26,8 +26,8 @@ by using the `--root-dir` argument. In addition, lets limit the data port range 
 
 ```sh
 unftp \
-  -v
+  -v \
   --root-dir=/home/unftp/data \
   --bind-address=0.0.0.0:2121 \
-  --passive-ports=50000-51000 \
+  --passive-ports=50000-51000
 ```


### PR DESCRIPTION
Docs page: https://unftp.rs/server/starting. It's about this command

```
unftp \
  -v
  --root-dir=/home/unftp/data \
  --bind-address=0.0.0.0:2121 \
  --passive-ports=50000-51000 \
```

If a new user would run the command like this:
1. There's no escaping after `-v`, so the options supplied afterwards won't get picked up 
2. The command won't be executed right away because of the `/` at the end

Both points are fixed in this pr