### PR TITLE
feat: add azblob storage backend with opendal

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -215,7 +215,7 @@ jobs:
           default: true
           target: ${{ env.target }}
       - name: Build for macOS (Intel)
-        run: cargo build --release --target=${{ env.target }} --features rest_auth,jsonfile_auth,cloud_storage
+        run: cargo build --release --target=${{ env.target }} --features rest_auth,jsonfile_auth,cloud_storage,azblob
       - name: Rename
         run: mv target/${{ env.target }}/release/unftp target/${{ env.target }}/release/unftp_${{ env.target }}
       - name: Upload build artifacts
@@ -247,7 +247,7 @@ jobs:
         if: runner.os == 'macOS' && runner.arch == 'arm64'
         run: softwareupdate --install-rosetta --agree-to-license
       - name: Build
-        run: cargo build --release --target=${{ env.target }} --features rest_auth,jsonfile_auth,cloud_storage
+        run: cargo build --release --target=${{ env.target }} --features rest_auth,jsonfile_auth,cloud_storage,azblob
       - name: Rename
         run: mv target/${{ env.target }}/release/unftp target/${{ env.target }}/release/unftp_${{ env.target }}
       - name: Upload build artifacts
@@ -283,7 +283,7 @@ jobs:
       #   id: latest_release_info
       #   uses: jossef/action-latest-release-info@v1.2.1
       #   env:
-      #     GITHUB_TOKEN: ${{ github.token }}    
+      #     GITHUB_TOKEN: ${{ github.token }}
       - name: Download
         uses: actions/download-artifact@v2
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1681,8 +1681,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opendal"
-version = "0.47.1"
-source = "git+https://github.com/apache/opendal.git#ea394689d95862a7dcf97a1ae746bcd745ff48e1"
+version = "0.47.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff159a2da374ef2d64848a6547943cf1af7d2ceada5ae77be175e1389aa07ae3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3336,8 +3337,9 @@ dependencies = [
 
 [[package]]
 name = "unftp-sbe-opendal"
-version = "0.0.0"
-source = "git+https://github.com/apache/opendal.git#ea394689d95862a7dcf97a1ae746bcd745ff48e1"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5b9696de453ada2438058efe294d205be114b7f047379341c7f7095a1677410"
 dependencies = [
  "async-trait",
  "libunftp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,9 +186,9 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.5",
+ "hyper 0.14.29",
  "itoa 1.0.11",
  "matchit",
  "memchr",
@@ -197,7 +197,7 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "tower",
  "tower-layer",
  "tower-service",
@@ -212,12 +212,24 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.5",
  "mime",
  "rustversion",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "backon"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d67782c3f868daa71d3533538e98a8e13713231969def7536e8039606fc46bf0"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "pin-project",
+ "tokio",
 ]
 
 [[package]]
@@ -407,8 +419,10 @@ checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-targets 0.52.5",
 ]
 
@@ -520,6 +534,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,6 +560,15 @@ name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crc32fast"
@@ -653,7 +682,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -727,6 +758,18 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+
+[[package]]
+name = "flagset"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb3aa5e95cf9aabc17f060cfa0ced7b83f042390760ca53bf09df9968acaa1"
 
 [[package]]
 name = "flate2"
@@ -876,8 +919,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -916,7 +961,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
  "indexmap 2.2.6",
  "slab",
  "tokio",
@@ -983,6 +1028,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "home"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1003,13 +1057,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa 1.0.11",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
@@ -1042,8 +1130,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.5",
  "httparse",
  "httpdate",
  "itoa 1.0.11",
@@ -1056,13 +1144,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "httparse",
+ "itoa 1.0.11",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.29",
  "log",
  "rustls 0.20.8",
  "rustls-native-certs",
@@ -1077,8 +1184,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.29",
  "log",
  "rustls 0.21.12",
  "rustls-native-certs",
@@ -1087,15 +1194,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.3.1",
+ "hyper-util",
+ "rustls 0.23.10",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.0",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
+ "hyper 0.14.29",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.3.1",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1535,6 +1680,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "opendal"
+version = "0.47.1"
+source = "git+https://github.com/apache/opendal.git#ea394689d95862a7dcf97a1ae746bcd745ff48e1"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "backon",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "flagset",
+ "futures",
+ "getrandom",
+ "http 1.1.0",
+ "log",
+ "md-5",
+ "once_cell",
+ "percent-encoding",
+ "quick-xml",
+ "reqsign",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1805,6 +1979,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ceeeeabace7857413798eb1ffa1e9c905a9946a57d81fb69b4b71c4d8eb3ad"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls 0.23.10",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddf517c03a109db8100448a4be38d498df8a210a99fe0e1b9eaf39e78c640efe"
+dependencies = [
+ "bytes",
+ "rand",
+ "ring 0.17.8",
+ "rustc-hash",
+ "rustls 0.23.10",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9096629c45860fc7fb143e125eb826b5e721e10be3263160c7d60ca832cf8c46"
+dependencies = [
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1875,7 +2106,7 @@ dependencies = [
  "dtoa",
  "itoa 0.4.8",
  "percent-encoding",
- "sha1",
+ "sha1 0.6.1",
  "url",
 ]
 
@@ -1951,6 +2182,76 @@ name = "regex-syntax"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+
+[[package]]
+name = "reqsign"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70fe66d4cd0b5ed9b1abbfe639bf6baeaaf509f7da2d51b31111ba945be59286"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64 0.22.1",
+ "chrono",
+ "form_urlencoded",
+ "getrandom",
+ "hex",
+ "hmac",
+ "home",
+ "http 1.1.0",
+ "log",
+ "percent-encoding",
+ "rand",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha1 0.10.6",
+ "sha2",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-rustls 0.27.2",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls 0.23.10",
+ "rustls-pemfile 2.1.2",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.1",
+ "tokio",
+ "tokio-rustls 0.26.0",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "webpki-roots",
+ "winreg",
+]
 
 [[package]]
 name = "ring"
@@ -2074,6 +2375,7 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
+ "ring 0.17.8",
  "rustls-pki-types",
  "rustls-webpki 0.102.4",
  "subtle",
@@ -2255,6 +2557,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa 1.0.11",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2264,10 +2578,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
 
 [[package]]
 name = "sharded-slab"
@@ -2494,6 +2830,12 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "synstructure"
@@ -2740,9 +3082,9 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "h2",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.5",
+ "hyper 0.14.29",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -2863,11 +3205,12 @@ dependencies = [
  "console-subscriber",
  "flate2",
  "futures",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.29",
  "hyper-rustls 0.23.2",
  "lazy_static",
  "libunftp",
+ "opendal",
  "pretty_assertions",
  "prometheus",
  "serde",
@@ -2885,6 +3228,7 @@ dependencies = [
  "unftp-auth-rest",
  "unftp-sbe-fs",
  "unftp-sbe-gcs",
+ "unftp-sbe-opendal",
  "unftp-sbe-restrict",
  "unftp-sbe-rooter",
  "url",
@@ -2932,7 +3276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdba42e5964ef945842167cab4c10fd12667dc12acbcfc702414f3d0262267ac"
 dependencies = [
  "async-trait",
- "hyper",
+ "hyper 0.14.29",
  "hyper-rustls 0.24.2",
  "libunftp",
  "percent-encoding",
@@ -2974,7 +3318,7 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
- "hyper",
+ "hyper 0.14.29",
  "hyper-rustls 0.24.2",
  "libunftp",
  "mime",
@@ -2988,6 +3332,18 @@ dependencies = [
  "tracing",
  "tracing-attributes",
  "yup-oauth2",
+]
+
+[[package]]
+name = "unftp-sbe-opendal"
+version = "0.0.0"
+source = "git+https://github.com/apache/opendal.git#ea394689d95862a7dcf97a1ae746bcd745ff48e1"
+dependencies = [
+ "async-trait",
+ "libunftp",
+ "opendal",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -3073,6 +3429,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 dependencies = [
  "getrandom",
+ "serde",
 ]
 
 [[package]]
@@ -3140,6 +3497,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3169,10 +3538,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
-name = "web-sys"
-version = "0.3.61"
+name = "wasm-streams"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3186,6 +3568,15 @@ checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
 dependencies = [
  "ring 0.16.20",
  "untrusted 0.7.1",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3437,6 +3828,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "winx"
 version = "0.36.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3479,8 +3880,8 @@ dependencies = [
  "async-trait",
  "base64 0.21.7",
  "futures",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.29",
  "hyper-rustls 0.24.2",
  "itertools",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,14 +62,15 @@ url = "2.5.2"
 unftp-auth-pam = { version = "0.2.5", optional = true }
 
 [features]
-default = ["rest_auth", "cloud_storage", "jsonfile_auth"]
+default = ["rest_auth", "cloud_storage", "jsonfile_auth", "opendal"]
 all_extentions = ["pam_auth", "rest_auth", "jsonfile_auth", "cloud_storage"]
 cloud_storage = ["unftp-sbe-gcs"]
 jsonfile_auth = ["unftp-auth-jsonfile"]
 pam_auth = ["unftp-auth-pam"]
 rest_auth = ["unftp-auth-rest"]
 tokio_console = ["console-subscriber", "tokio/tracing"]
-azblob = ["dep:unftp-sbe-opendal", "dep:opendal", "opendal/services-azblob"]
+opendal = ["dep:unftp-sbe-opendal", "dep:opendal"]
+azblob = ["opendal/services-azblob"]
 
 # With this we link dynamically to libc and pam
 gnu = ["all_extentions"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,9 +50,8 @@ thiserror = "1.0.61"
 tokio = { version = "1.38.0", features = ["signal", "rt-multi-thread"] }
 unftp-sbe-fs = "0.2.5"
 unftp-sbe-gcs = { version = "0.2.6", optional = true }
-# unftp-sbe-opendal = { version = "0.0.0", optional = true }
-opendal = { version = "0.47.1", optional = true, git = "https://github.com/apache/opendal.git" }
-unftp-sbe-opendal = { version = "0.0.0", optional = true, git = "https://github.com/apache/opendal.git" }
+unftp-sbe-opendal = { version = "0.0.1", optional = true }
+opendal = { version = "0.47.1", optional = true }
 unftp-auth-rest = { version = "0.2.6", optional = true }
 unftp-auth-jsonfile = { version = "0.3.4", optional = true }
 unftp-sbe-rooter = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ unftp-auth-pam = { version = "0.2.5", optional = true }
 
 [features]
 default = ["rest_auth", "cloud_storage", "jsonfile_auth", "opendal"]
-all_extentions = ["pam_auth", "rest_auth", "jsonfile_auth", "cloud_storage"]
+all_extentions = ["pam_auth", "rest_auth", "jsonfile_auth", "cloud_storage", "opendal"]
 cloud_storage = ["unftp-sbe-gcs"]
 jsonfile_auth = ["unftp-auth-jsonfile"]
 pam_auth = ["unftp-auth-pam"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,9 @@ thiserror = "1.0.61"
 tokio = { version = "1.38.0", features = ["signal", "rt-multi-thread"] }
 unftp-sbe-fs = "0.2.5"
 unftp-sbe-gcs = { version = "0.2.6", optional = true }
+# unftp-sbe-opendal = { version = "0.0.0", optional = true }
+opendal = { version = "0.47.1", optional = true, git = "https://github.com/apache/opendal.git" }
+unftp-sbe-opendal = { version = "0.0.0", optional = true, git = "https://github.com/apache/opendal.git" }
 unftp-auth-rest = { version = "0.2.6", optional = true }
 unftp-auth-jsonfile = { version = "0.3.4", optional = true }
 unftp-sbe-rooter = "0.2.1"
@@ -67,7 +70,7 @@ jsonfile_auth = ["unftp-auth-jsonfile"]
 pam_auth = ["unftp-auth-pam"]
 rest_auth = ["unftp-auth-rest"]
 tokio_console = ["console-subscriber", "tokio/tracing"]
-
+azblob = ["dep:unftp-sbe-opendal", "dep:opendal", "opendal/services-azblob"]
 
 # With this we link dynamically to libc and pam
 gnu = ["all_extentions"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ azblob = ["dep:unftp-sbe-opendal", "dep:opendal", "opendal/services-azblob"]
 gnu = ["all_extentions"]
 
 # All features able to link statically
-musl = ["rest_auth", "cloud_storage", "jsonfile_auth"]
+musl = ["rest_auth", "cloud_storage", "jsonfile_auth", "azblob"]
 
 # Features used in our docker builds
 docker = ["musl"]

--- a/docs/libunftp/README.md
+++ b/docs/libunftp/README.md
@@ -10,7 +10,7 @@ title: The Library
 
 # libunftp - The FTPS library
 
-**libunftp** is a [Rust](https://www.rust-lang.org/) [crate](https://crates.io/crates/libunftp) that you can use to 
+**libunftp** is a [Rust](https://www.rust-lang.org/) [crate](https://crates.io/crates/libunftp) that you can use to
 build your own FTPS server with. You can extend it with your own storage back-ends or authentication back-ends.
 
 It runs on top of the [Tokio](https://tokio.rs) asynchronous run-time and tries to make use of Async IO as much as
@@ -36,6 +36,7 @@ Known storage back-ends:
 * [unftp-sbe-gcs](https://crates.io/crates/unftp-sbe-gcs) - Stores files in Google Cloud Storage
 * [unftp-sbe-rooter](https://crates.io/crates/unftp-sbe-rooter) - Wraps another storage back-end in order to root a user to a specific home directory.
 * [unftp-sbe-restrict](https://crates.io/crates/unftp-sbe-rooter) - Wraps another storage back-end in order to restrict the FTP operations a user can do i.e. provide authorization.
+* [unftp-sbe-opendal](https://crates.io/crates/unftp-sbe-opendal) - Access ANY storage back-end using OpenDAL.
 
 Known authentication back-ends:
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -27,6 +27,13 @@ pub const GCS_BUCKET: &str = "sbe-gcs-bucket";
 pub const GCS_KEY_FILE: &str = "sbe-gcs-key-file";
 pub const GCS_ROOT: &str = "sbe-gcs-root";
 pub const GCS_SERVICE_ACCOUNT: &str = "sbe-gcs-service-account";
+pub const AZBLOB_ROOT: &str = "sbe-opendal-azblob-root";
+pub const AZBLOB_CONTAINER: &str = "sbe-opendal-azblob-container";
+pub const AZBLOB_ENDPOINT: &str = "sbe-opendal-azblob-endpoint";
+pub const AZBLOB_ACCOUNT_NAME: &str = "sbe-opendal-azblob-account-name";
+pub const AZBLOB_ACCOUNT_KEY: &str = "sbe-opendal-azblob-account-key";
+pub const AZBLOB_SAS_TOKEN: &str = "sbe-opendal-azblob-sas-token";
+pub const AZBLOB_BATCH_MAX_OPERATIONS: &str = "sbe-opendal-azblob-batch-max-operations";
 pub const HTTP_BIND_ADDRESS: &str = "bind-address-http";
 pub const IDLE_SESSION_TIMEOUT: &str = "idle-session-timeout";
 pub const INSTANCE_NAME: &str = "instance-name";
@@ -60,6 +67,7 @@ pub enum AuthType {
 pub enum StorageBackendType {
     filesystem,
     gcs,
+    azblob,
 }
 
 #[derive(ArgEnum, Clone, Debug)]
@@ -471,6 +479,54 @@ pub(crate) fn clap_app(tmp_dir: &str) -> clap::Command {
                 .help("The name of the service account to use when authenticating using GKE workload identity.")
                 .env("UNFTP_SBE_GCS_SERVICE_ACCOUNT")
                 .takes_value(true),
+        )
+        .arg(
+            Arg::new(AZBLOB_ROOT)
+            .long("sbe-opendal-azblob-root")
+            .help("Root of this backend. All operations will happen under this root.")
+            .env("UNFTP_SBE_OPENDAL_AZBLOB_ROOT")
+            .takes_value(true))
+        .arg(
+            Arg::new(AZBLOB_CONTAINER)
+            .long("sbe-opendal-azblob-container")
+            .help("Container name of this backend.")
+            .env("UNFTP_SBE_OPENDAL_AZBLOB_CONTAINER")
+            .takes_value(true)
+        )
+        .arg(
+            Arg::new(AZBLOB_ENDPOINT)
+            .long("sbe-opendal-azblob-endpoint")
+            .help("Endpoint of this backend. Endpoint must be full uri.")
+            .env("UNFTP_SBE_OPENDAL_AZBLOB_ENDPOINT")
+            .takes_value(true)
+        )
+        .arg(
+            Arg::new(AZBLOB_ACCOUNT_NAME)
+            .long("sbe-opendal-azblob-account-name")
+            .help("Set account_name of this backend. If account_name is set, we will take user's input first. If not, we will try to load it from environment.")
+            .env("UNFTP_SBE_OPENDAL_AZBLOB_ACCOUNT_NAME")
+            .takes_value(true)
+        )
+        .arg(
+            Arg::new(AZBLOB_ACCOUNT_KEY)
+            .long("sbe-opendal-azblob-account-key")
+            .help("Set account_key of this backend. If account_name is set, we will take user's input first. If not, we will try to load it from environment.")
+            .env("UNFTP_SBE_OPENDAL_AZBLOB_ACCOUNT_KEY")
+            .takes_value(true)
+        )
+        .arg(
+            Arg::new(AZBLOB_SAS_TOKEN)
+            .long("sbe-opendal-azblob-sas-token")
+            .help("Set sas_token of this backend. If account_name is set, we will take user's input first. If not, we will try to load it from environment. See https://learn.microsoft.com/en-us/azure/storage/common/storage-sas-overview for more info.")
+            .env("UNFTP_SBE_OPENDAL_AZBLOB_SAS_TOKEN")
+            .takes_value(true)
+        )
+        .arg(
+            Arg::new(AZBLOB_BATCH_MAX_OPERATIONS)
+            .long("sbe-opendal-azblob-batch-max-operations")
+            .help("Set maximum batch operations of this backend.")
+            .env("UNFTP_SBE_OPENDAL_AZBLOB_BATCH_MAX_OPERATIONS")
+            .takes_value(true)
         )
         .arg(
             Arg::new(IDLE_SESSION_TIMEOUT)

--- a/src/main.rs
+++ b/src/main.rs
@@ -387,10 +387,9 @@ fn azblob_storage_backend(log: &Logger, m: &clap::ArgMatches) -> Result<VfsProdu
             })?,
         );
     }
-    let accessor = b
-        .build()
-        .map_err(|e| format!("could not build Azblob: {e}"))?;
-    let op = opendal::OperatorBuilder::new(accessor).finish();
+    let op = opendal::Operator::new(b)
+        .map_err(|e| format!("could not build Azblob: {e}"))?
+        .finish();
     let sbe = unftp_sbe_opendal::OpendalStorage::new(op);
     let sub_log = Arc::new(log.new(o!("module" => "storage")));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,6 @@ use libunftp::{
     storage::StorageBackend,
     ServerBuilder,
 };
-use opendal::Builder;
 use slog::*;
 use std::io::{Read, Seek};
 use std::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -359,7 +359,8 @@ fn gcs_storage_backend(log: &Logger, m: &clap::ArgMatches) -> Result<VfsProducer
     }))
 }
 
-fn azblob_storage_backend(log: &Logger, m: &clap::ArgMatches) -> Result<VfsProducer, String> {
+#[cfg(feature = "azblob")]
+pub fn azblob_storage_backend(log: &Logger, m: &clap::ArgMatches) -> Result<VfsProducer, String> {
     let mut b = opendal::services::Azblob::default();
     if let Some(val) = m.value_of(args::AZBLOB_ROOT) {
         b.root(val);
@@ -417,6 +418,7 @@ fn start_ftp(
     match m.value_of(args::STORAGE_BACKEND_TYPE) {
         None | Some("filesystem") => svc(fs_storage_backend(root_log, m)),
         Some("gcs") => svc(gcs_storage_backend(root_log, m)?),
+        #[cfg(feature = "azblob")]
         Some("azblob") => svc(azblob_storage_backend(root_log, m)?),
         Some(x) => Err(format!("unknown storage back-end type {}", x)),
     }


### PR DESCRIPTION
This PR adds azure blob support with OpenDAL. Currently we are still waiting for `unftp-sbe-opendal` to release, so it's a git dependency for now. Azure blob can be used as an example for future implementation of storages backed by OpenDAL. 

I'm not sure how should we organize the naming (arg, env) for services provided by OpenDAL though. 

Closes #183 
