### PR TITLE
Website: Fix UNFTP_ROOT_URL in docker docs and add more passive ports

### DIFF
--- a/docs/server/docker.md
+++ b/docs/server/docker.md
@@ -14,7 +14,7 @@ Example running unFTP in a Docker container:
 
 ```sh
 docker run \
-  -e ROOT_DIR=/ \
+  -e UNFTP_ROOT_DIR=/ \
   -e UNFTP_LOG_LEVEL=info \
   -e UNFTP_FTPS_CERTS_FILE='/unftp.crt' \
   -e UNFTP_FTPS_KEY_FILE='/unftp.key' \
@@ -23,12 +23,7 @@ docker run \
   -e UNFTP_SBE_GCS_BUCKET=the-bucket-name \
   -e UNFTP_SBE_GCS_KEY_FILE=/key.json \
   -p 2121:2121 \
-  -p 50000:50000 \
-  -p 50001:50001 \
-  -p 50002:50002 \
-  -p 50003:50003 \
-  -p 50004:50004 \
-  -p 50005:50005 \
+  -p 50000-50020:50000-50020 \
   -p 8080:8080 \
   -v /Users/xxx/unftp/unftp.key:/unftp.key  \
   -v /Users/xxx/unftp/unftp.crt:/unftp.crt \
@@ -36,4 +31,3 @@ docker run \
   -ti \
   bolcom/unftp:v0.14.7-alpine
 ```
-


### PR DESCRIPTION
The ROOT_URL was incorrect and should have been UNFTP_ROOT_URL. Has been discussed in this issue: #164
Also adds more passive ports to help avoid issues until #187 is resolved.