### PR TITLE
Auth-type now a mandatory parameter (breaking change)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## 2024-12-14 unftp v0.14.8
+## 2024-12-14 unftp v0.15.0
 
 - [#184](https://github.com/bolcom/unFTP/pull/184) Support for Azure blob storage with [OpenDAL](https://github.com/apache/OpenDAL)
 - [#185](https://github.com/bolcom/unFTP/pull/185) Support for shipping logs to [Google Logging](https://cloud.google.com/logging/docs/)
+- [#196](https://github.com/bolcom/unFTP/pull/196) --auth-type is now mandatory to prevent security risks from omission or typos that could leave the FTP server open
 
 ## 2023-12-24 unftp v0.14.7
 

--- a/docs/server/ftps.md
+++ b/docs/server/ftps.md
@@ -37,7 +37,7 @@ openssl req -new -x509 -days 365 \
 	-key unftp_client_ca.key \
         -subj '/CN=unftp-ca.mysite.com/O=bol.com/C=NL' \
 	-out unftp_client_ca.crt
-````
+```
 
 Create a client side key:
 

--- a/docs/server/starting.md
+++ b/docs/server/starting.md
@@ -9,11 +9,16 @@ program arguments type the following:
 unftp --help
 ```
 
-To run unFTP with everything set to the defaults:
+To run passwordless unFTP with everything set to the defaults:
 
 ```sh
-unftp
+unftp --auth-type anonymous
 ```
+
+{% info Note %}
+The `--auth-type` switch is required, but will be omitted in many other examples for brevity.
+Choose the appropriate authentication type for your use case—do not use anonymous unless explicitly intended.
+{% end %}
 
 This will start unFTP:
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -372,8 +372,7 @@ pub(crate) fn clap_app(tmp_dir: &str) -> clap::Command {
                 .help("The type of authorization to use")
                 //.case_insensitive(true)
                 .env("UNFTP_AUTH_TYPE")
-                .takes_value(true)
-                .default_value("anonymous"),
+                .takes_value(true),
         )
         .arg(
             Arg::new(AUTH_PAM_SERVICE)

--- a/src/main.rs
+++ b/src/main.rs
@@ -858,15 +858,18 @@ async fn run(arg_matches: ArgMatches) -> Result<(), String> {
     let (root_logger, google_shipper) = logging::create_logger(&arg_matches)?;
     let log = root_logger.new(o!("module" => "main"));
 
-    let addr = String::from(arg_matches.value_of(args::BIND_ADDRESS).unwrap());
-    let http_addr = String::from(arg_matches.value_of(args::HTTP_BIND_ADDRESS).unwrap());
-    let auth_type = String::from(arg_matches.value_of(args::AUTH_TYPE).unwrap());
-    let sbe_type = String::from(arg_matches.value_of(args::STORAGE_BACKEND_TYPE).unwrap());
+    let addr = arg_matches.value_of(args::BIND_ADDRESS).unwrap();
+    let http_addr = arg_matches.value_of(args::HTTP_BIND_ADDRESS).unwrap();
+    let auth_type = arg_matches.value_of(args::AUTH_TYPE).unwrap_or_else(|| {
+        eprintln!("Required option --auth-type is missing. To disable authentication, use: `--auth-type anonymous` or set the `UNFTP_AUTH_TYPE=anonymous` environment variable.");
+        ::std::process::exit(1)
+    });
+    let sbe_type = arg_matches.value_of(args::STORAGE_BACKEND_TYPE).unwrap();
 
-    let home_dir = String::from(match &*sbe_type {
+    let home_dir = match sbe_type {
         "gcs" => arg_matches.value_of(args::GCS_ROOT).unwrap(),
         _ => arg_matches.value_of(args::ROOT_DIR).unwrap(),
-    });
+    };
 
     info!(log, "Starting {} server.", app::NAME;
     "version" => app::VERSION,

--- a/src/main.rs
+++ b/src/main.rs
@@ -861,7 +861,7 @@ async fn run(arg_matches: ArgMatches) -> Result<(), String> {
     let addr = arg_matches.value_of(args::BIND_ADDRESS).unwrap();
     let http_addr = arg_matches.value_of(args::HTTP_BIND_ADDRESS).unwrap();
     let auth_type = arg_matches.value_of(args::AUTH_TYPE).unwrap_or_else(|| {
-        eprintln!("Required option --auth-type is missing. To disable authentication, use: `--auth-type anonymous` or set the `UNFTP_AUTH_TYPE=anonymous` environment variable.");
+        eprintln!("Required option --auth-type is missing. To disable authentication, use: `--auth-type=anonymous` or set the `UNFTP_AUTH_TYPE=anonymous` environment variable.");
         ::std::process::exit(1)
     });
     let sbe_type = arg_matches.value_of(args::STORAGE_BACKEND_TYPE).unwrap();


### PR DESCRIPTION
Before, --auth-type had a default option of anonymous. That way unftp doesn't require any arguments to start up. But we figured this is a potential security hazard: Forgetting to set --auth-type, or making a typo like --authtype would be disastrous.

So this is now disabled.
If you do not pass the --auth-type argument, unFTP will refuse to start up.

If you intentionally want to run a passwordless FTP server, you can pass `--auth-type anonymous` explicitly.