### PR TITLE
Add ISO storage type

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,7 @@ name: build
 # Update the RUST_VERSION here and in the Makefile when we upgrade
 env:
   CARGO_TERM_COLOR: always
-  RUST_VERSION: 1.83.0
+  RUST_VERSION: 1.86.0
 
 on:
   push:
@@ -78,6 +78,8 @@ jobs:
           override: true
           default: true
           components: clippy
+      - name: Install build dependencies
+        run: sudo apt-get update && sudo apt-get install -y libfuse-dev
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
@@ -97,7 +99,7 @@ jobs:
           default: true
           components: clippy
       - name: Install build dependencies
-        run: sudo apt-get update && sudo apt-get install -y libpam-dev
+        run: sudo apt-get update && sudo apt-get install -y libpam-dev libfuse-dev
       - name: Run tests
         run: cargo test --verbose  --workspace --all --all-features
       - name: Build Docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Next release
+
+- Upgraded dependencies
+- Compile against Rust 1.86.0
+- [#210](https://github.com/bolcom/unFTP/pull/210) Added new `iso` storage back-end gated behind the `sbe_iso` feature.
+
 ## 2024-12-14 unftp v0.15.1
 
 - Upgrade libunftp to 0.20.3 solving '425' errors for passive listening ports
@@ -9,11 +15,15 @@
 - Upgraded to new auth and storage backend releases
 - Upgraded dependencies including all crates from https://github.com/bolcom/libunftp
 - Upgraded to Rust 1.83.0
-- [#196](https://github.com/bolcom/unFTP/pull/196) *Breaking* --auth-type is now mandatory to prevent security risks from omission or typos that could leave the FTP server open
-- [#184](https://github.com/bolcom/unFTP/pull/184) Support for Azure blob storage with [OpenDAL](https://github.com/apache/OpenDAL)
-- [#185](https://github.com/bolcom/unFTP/pull/185) Support for shipping logs to [Google Logging](https://cloud.google.com/logging/docs/)
+- [#196](https://github.com/bolcom/unFTP/pull/196) *Breaking* --auth-type is now mandatory to prevent security risks
+  from omission or typos that could leave the FTP server open
+- [#184](https://github.com/bolcom/unFTP/pull/184) Support for Azure blob storage
+  with [OpenDAL](https://github.com/apache/OpenDAL)
+- [#185](https://github.com/bolcom/unFTP/pull/185) Support for shipping logs
+  to [Google Logging](https://cloud.google.com/logging/docs/)
 - [#191](https://github.com/bolcom/unFTP/pull/191) Allow https for user detail
-- [#199](https://github.com/bolcom/unFTP/pull/199) Removed istio (scuttle) image build in favor of using `proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'`
+- [#199](https://github.com/bolcom/unFTP/pull/199) Removed istio (scuttle) image build in favor of using
+  `proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'`
 
 ## 2023-12-24 unftp v0.14.7
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
 name = "anyhow"
 version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,7 +249,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -385,6 +391,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "cdfs"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efdb3190d131cec95691d0b895a3e43b75d21b071887739233f42352d5b7085a"
+dependencies = [
+ "anyhow",
+ "bitflags 2.6.0",
+ "cfg-if",
+ "clap 4.5.37",
+ "encoding_rs",
+ "fuser",
+ "itertools 0.11.0",
+ "libc",
+ "log",
+ "nom",
+ "simple_logger",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,7 +444,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -439,13 +466,34 @@ checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
  "bitflags 1.3.2",
- "clap_derive",
- "clap_lex",
+ "clap_derive 3.2.25",
+ "clap_lex 0.2.4",
  "indexmap 1.9.3",
  "once_cell",
  "strsim 0.10.0",
  "termcolor",
  "textwrap",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
+dependencies = [
+ "clap_builder",
+ "clap_derive 4.5.32",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
+dependencies = [
+ "anstyle",
+ "clap_lex 0.7.4",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -462,6 +510,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_derive"
+version = "4.5.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "clap_lex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,6 +529,12 @@ checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "cmake"
@@ -773,6 +839,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,6 +916,21 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fuser"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21370f84640642c8ea36dfb2a6bfc4c55941f476fcf431f6fef25a5ddcf0169b"
+dependencies = [
+ "libc",
+ "log",
+ "memchr",
+ "page_size",
+ "pkg-config",
+ "smallvec",
+ "zerocopy 0.6.6",
+]
 
 [[package]]
 name = "futures"
@@ -1581,6 +1671,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
@@ -1665,7 +1764,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1979,6 +2078,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
+name = "page_size"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b7663cbd190cfd818d08efa8497f6cd383076688c49a391ef7c0d03cd12b561"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "pam"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2018,7 +2127,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2101,7 +2210,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -2954,6 +3063,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple_logger"
+version = "4.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e7e46c8c90251d47d08b28b8a419ffb4aede0f87c2eea95e17d1d5bacbf3ef1"
+dependencies = [
+ "log",
+ "time",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3613,10 +3733,9 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "built",
- "clap",
+ "clap 3.2.25",
  "console-subscriber",
  "flate2",
- "futures",
  "http 0.2.12",
  "hyper 0.14.31",
  "hyper-rustls 0.23.2",
@@ -3641,6 +3760,7 @@ dependencies = [
  "unftp-auth-rest",
  "unftp-sbe-fs",
  "unftp-sbe-gcs",
+ "unftp-sbe-iso",
  "unftp-sbe-opendal",
  "unftp-sbe-restrict",
  "unftp-sbe-rooter",
@@ -3745,6 +3865,18 @@ dependencies = [
  "tracing",
  "tracing-attributes",
  "yup-oauth2 8.3.2",
+]
+
+[[package]]
+name = "unftp-sbe-iso"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf1beb26fc9b1015594d67f73f98984bf9a8d5e0f574fdb73874a11d7a1d1392"
+dependencies = [
+ "async-trait",
+ "cdfs",
+ "libunftp",
+ "tokio",
 ]
 
 [[package]]
@@ -4076,7 +4208,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4087,7 +4219,7 @@ checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
 dependencies = [
  "windows-result",
  "windows-strings",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4096,7 +4228,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4106,7 +4238,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result",
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4115,7 +4256,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4124,7 +4265,22 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -4133,15 +4289,21 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -4151,9 +4313,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4169,9 +4343,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4181,9 +4367,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4325,12 +4523,33 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854e949ac82d619ee9a14c66a1b674ac730422372ccb759ce0c39cabcf2bf8e6"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive 0.6.6",
+]
+
+[[package]]
+name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ base64 = "0.22.1"
 clap = { version = "3.2.25", features = ["derive", "env"] }
 console-subscriber = { version = "0.3.0", optional = true }
 flate2 = "1.0.35"
-futures = "0.3.31"
 http = "0.2.12"
 hyper = { version = "0.14.31", features = ["server", "http1"] }
 hyper-rustls = "0.23.2"
@@ -57,6 +56,7 @@ tokio = { version = "1.42.0", features = ["signal", "rt-multi-thread"] }
 unftp-sbe-fs = "0.2.6"
 unftp-sbe-gcs = { version = "0.2.7", optional = true }
 unftp-sbe-opendal = { version = "0.0.1", optional = true }
+unftp-sbe-iso = { version = "0.1.0", optional = true }
 unftp-auth-rest = { version = "0.2.7", optional = true }
 unftp-auth-jsonfile = { version = "0.3.5", optional = true }
 unftp-sbe-rooter = "0.2.1"
@@ -68,17 +68,23 @@ unftp-auth-pam = { version = "0.2.5", optional = true }
 
 [features]
 default = ["rest_auth", "cloud_storage", "jsonfile_auth", "opendal"]
-all_extentions = ["pam_auth", "rest_auth", "jsonfile_auth", "cloud_storage", "opendal"]
-cloud_storage = ["unftp-sbe-gcs"]
-jsonfile_auth = ["unftp-auth-jsonfile"]
-pam_auth = ["unftp-auth-pam"]
-rest_auth = ["unftp-auth-rest"]
-tokio_console = ["console-subscriber", "tokio/tracing"]
+tokio_console = ["dep:console-subscriber", "tokio/tracing"]
+
+## Storage back-end extentions
+cloud_storage = ["dep:unftp-sbe-gcs"]
 opendal = ["dep:unftp-sbe-opendal", "dep:opendal"]
 azblob = ["opendal/services-azblob"]
+sbe_iso = ["dep:unftp-sbe-iso"]
+
+## Auth back-end extentions
+pam_auth = ["dep:unftp-auth-pam"]
+rest_auth = ["dep:unftp-auth-rest"]
+jsonfile_auth = ["dep:unftp-auth-jsonfile"]
+
+all_extentions = ["pam_auth", "rest_auth", "jsonfile_auth", "cloud_storage", "opendal", "sbe_iso"]
 
 # With this we link dynamically to libc and pam
-gnu = ["all_extentions"]
+gnu = ["pam_auth", "rest_auth", "jsonfile_auth", "cloud_storage", "opendal"]
 
 # All features able to link statically
 musl = ["rest_auth", "cloud_storage", "jsonfile_auth", "azblob"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-RUST_VERSION=1.83.0
+RUST_VERSION=1.86.0
 DOCKER_TAG=$(shell git describe --tags)
 DOCKER_TEMPLATES:=$(wildcard *.Dockerfile.template)
 DOCKER_FILES=$(DOCKER_TEMPLATES:%.template=%)

--- a/packaging/docker/alpine-debug.Dockerfile.ci
+++ b/packaging/docker/alpine-debug.Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM rust:1.83.0-slim AS builder
+FROM rust:1.86.0-slim AS builder
 
 FROM alpine:3.21
 

--- a/packaging/docker/alpine.Dockerfile.ci
+++ b/packaging/docker/alpine.Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM rust:1.83.0-slim AS builder
+FROM rust:1.86.0-slim AS builder
 
 FROM alpine:latest
 

--- a/packaging/docker/scratch.Dockerfile.ci
+++ b/packaging/docker/scratch.Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM rust:1.83.0-slim AS builder
+FROM rust:1.86.0-slim AS builder
 
 FROM scratch
 

--- a/src/infra/pubsub.rs
+++ b/src/infra/pubsub.rs
@@ -163,11 +163,12 @@ struct PubSubMsg {
 #[cfg(test)]
 mod tests {
     use crate::infra::pubsub::{PubSubMsg, PubSubRequest};
+    use base64::Engine;
     use std::collections::HashMap;
 
     #[test]
     fn pubub_request_serializes_correctly() {
-        let payload = base64::encode("123");
+        let payload = base64::engine::general_purpose::STANDARD.encode("123");
         let r = PubSubRequest {
             messages: vec![PubSubMsg {
                 data: payload,

--- a/src/storage/choose.rs
+++ b/src/storage/choose.rs
@@ -27,6 +27,8 @@ pub enum InnerVfs {
     OpenDAL(unftp_sbe_opendal::OpendalStorage),
     Cloud(unftp_sbe_gcs::CloudStorage),
     File(unftp_sbe_fs::Filesystem),
+    #[cfg(feature = "sbe_iso")]
+    Iso(unftp_sbe_iso::Storage),
 }
 
 #[derive(Debug)]
@@ -34,6 +36,8 @@ pub enum SbeMeta {
     OpenDAL(unftp_sbe_opendal::OpendalMetadata),
     Cloud(unftp_sbe_gcs::object_metadata::ObjectMetadata),
     File(unftp_sbe_fs::Meta),
+    #[cfg(feature = "sbe_iso")]
+    Iso(unftp_sbe_iso::IsoMeta),
 }
 
 impl libunftp::storage::Metadata for SbeMeta {
@@ -42,6 +46,8 @@ impl libunftp::storage::Metadata for SbeMeta {
             SbeMeta::OpenDAL(m) => m.len(),
             SbeMeta::Cloud(m) => m.len(),
             SbeMeta::File(m) => m.len(),
+            #[cfg(feature = "sbe_iso")]
+            SbeMeta::Iso(m) => m.len(),
         }
     }
 
@@ -50,6 +56,8 @@ impl libunftp::storage::Metadata for SbeMeta {
             SbeMeta::OpenDAL(m) => m.is_dir(),
             SbeMeta::Cloud(m) => m.is_dir(),
             SbeMeta::File(m) => m.is_dir(),
+            #[cfg(feature = "sbe_iso")]
+            SbeMeta::Iso(m) => m.is_dir(),
         }
     }
 
@@ -58,6 +66,8 @@ impl libunftp::storage::Metadata for SbeMeta {
             SbeMeta::OpenDAL(m) => m.is_file(),
             SbeMeta::Cloud(m) => m.is_file(),
             SbeMeta::File(m) => m.is_file(),
+            #[cfg(feature = "sbe_iso")]
+            SbeMeta::Iso(m) => m.is_file(),
         }
     }
 
@@ -66,6 +76,8 @@ impl libunftp::storage::Metadata for SbeMeta {
             SbeMeta::OpenDAL(m) => m.is_symlink(),
             SbeMeta::Cloud(m) => m.is_symlink(),
             SbeMeta::File(m) => m.is_symlink(),
+            #[cfg(feature = "sbe_iso")]
+            SbeMeta::Iso(m) => m.is_symlink(),
         }
     }
 
@@ -74,6 +86,8 @@ impl libunftp::storage::Metadata for SbeMeta {
             SbeMeta::OpenDAL(m) => m.modified(),
             SbeMeta::Cloud(m) => m.modified(),
             SbeMeta::File(m) => m.modified(),
+            #[cfg(feature = "sbe_iso")]
+            SbeMeta::Iso(m) => m.modified(),
         }
     }
 
@@ -82,6 +96,8 @@ impl libunftp::storage::Metadata for SbeMeta {
             SbeMeta::OpenDAL(m) => m.gid(),
             SbeMeta::Cloud(m) => m.gid(),
             SbeMeta::File(m) => m.gid(),
+            #[cfg(feature = "sbe_iso")]
+            SbeMeta::Iso(m) => m.gid(),
         }
     }
 
@@ -90,6 +106,8 @@ impl libunftp::storage::Metadata for SbeMeta {
             SbeMeta::OpenDAL(m) => m.uid(),
             SbeMeta::Cloud(m) => m.uid(),
             SbeMeta::File(m) => m.uid(),
+            #[cfg(feature = "sbe_iso")]
+            SbeMeta::Iso(m) => m.uid(),
         }
     }
 }
@@ -103,6 +121,8 @@ impl StorageBackend<User> for ChoosingVfs {
             InnerVfs::OpenDAL(i) => StorageBackend::<User>::name(i),
             InnerVfs::Cloud(i) => StorageBackend::<User>::name(i),
             InnerVfs::File(i) => StorageBackend::<User>::name(i),
+            #[cfg(feature = "sbe_iso")]
+            InnerVfs::Iso(i) => StorageBackend::<User>::name(i),
         }
     }
 
@@ -111,6 +131,8 @@ impl StorageBackend<User> for ChoosingVfs {
             InnerVfs::OpenDAL(i) => StorageBackend::<User>::supported_features(i),
             InnerVfs::Cloud(i) => StorageBackend::<User>::supported_features(i),
             InnerVfs::File(i) => StorageBackend::<User>::supported_features(i),
+            #[cfg(feature = "sbe_iso")]
+            InnerVfs::Iso(i) => StorageBackend::<User>::supported_features(i),
         }
     }
 
@@ -123,6 +145,8 @@ impl StorageBackend<User> for ChoosingVfs {
             InnerVfs::OpenDAL(i) => i.metadata(user, path).await.map(SbeMeta::OpenDAL),
             InnerVfs::Cloud(i) => i.metadata(user, path).await.map(SbeMeta::Cloud),
             InnerVfs::File(i) => i.metadata(user, path).await.map(SbeMeta::File),
+            #[cfg(feature = "sbe_iso")]
+            InnerVfs::Iso(i) => i.metadata(user, path).await.map(SbeMeta::Iso),
         }
     }
 
@@ -159,6 +183,15 @@ impl StorageBackend<User> for ChoosingVfs {
                     })
                     .collect()
             }),
+            #[cfg(feature = "sbe_iso")]
+            InnerVfs::Iso(i) => i.list(user, path).await.map(|v| {
+                v.into_iter()
+                    .map(|fi| Fileinfo {
+                        path: fi.path,
+                        metadata: SbeMeta::Iso(fi.metadata),
+                    })
+                    .collect()
+            }),
         }
     }
 
@@ -171,6 +204,8 @@ impl StorageBackend<User> for ChoosingVfs {
             InnerVfs::OpenDAL(i) => i.list_fmt(user, path).await,
             InnerVfs::Cloud(i) => i.list_fmt(user, path).await,
             InnerVfs::File(i) => i.list_fmt(user, path).await,
+            #[cfg(feature = "sbe_iso")]
+            InnerVfs::Iso(i) => i.list_fmt(user, path).await,
         }
     }
 
@@ -183,6 +218,8 @@ impl StorageBackend<User> for ChoosingVfs {
             InnerVfs::OpenDAL(i) => i.nlst(user, path).await,
             InnerVfs::Cloud(i) => i.nlst(user, path).await,
             InnerVfs::File(i) => i.nlst(user, path).await,
+            #[cfg(feature = "sbe_iso")]
+            InnerVfs::Iso(i) => i.nlst(user, path).await,
         }
     }
 
@@ -201,6 +238,8 @@ impl StorageBackend<User> for ChoosingVfs {
             InnerVfs::OpenDAL(i) => i.get_into(user, path, start_pos, output).await,
             InnerVfs::Cloud(i) => i.get_into(user, path, start_pos, output).await,
             InnerVfs::File(i) => i.get_into(user, path, start_pos, output).await,
+            #[cfg(feature = "sbe_iso")]
+            InnerVfs::Iso(i) => i.get_into(user, path, start_pos, output).await,
         }
     }
 
@@ -214,6 +253,8 @@ impl StorageBackend<User> for ChoosingVfs {
             InnerVfs::OpenDAL(i) => i.get(user, path, start_pos).await,
             InnerVfs::Cloud(i) => i.get(user, path, start_pos).await,
             InnerVfs::File(i) => i.get(user, path, start_pos).await,
+            #[cfg(feature = "sbe_iso")]
+            InnerVfs::Iso(i) => i.get(user, path, start_pos).await,
         }
     }
 
@@ -243,6 +284,8 @@ impl StorageBackend<User> for ChoosingVfs {
             InnerVfs::OpenDAL(i) => i.put(user, input, path, start_pos).await,
             InnerVfs::Cloud(i) => i.put(user, input, path, start_pos).await,
             InnerVfs::File(i) => i.put(user, input, path, start_pos).await,
+            #[cfg(feature = "sbe_iso")]
+            InnerVfs::Iso(i) => i.put(user, input, path, start_pos).await,
         }
     }
 
@@ -255,6 +298,8 @@ impl StorageBackend<User> for ChoosingVfs {
             InnerVfs::OpenDAL(i) => i.del(user, path).await,
             InnerVfs::Cloud(i) => i.del(user, path).await,
             InnerVfs::File(i) => i.del(user, path).await,
+            #[cfg(feature = "sbe_iso")]
+            InnerVfs::Iso(i) => i.del(user, path).await,
         }
     }
 
@@ -267,6 +312,8 @@ impl StorageBackend<User> for ChoosingVfs {
             InnerVfs::OpenDAL(i) => i.mkd(user, path).await,
             InnerVfs::Cloud(i) => i.mkd(user, path).await,
             InnerVfs::File(i) => i.mkd(user, path).await,
+            #[cfg(feature = "sbe_iso")]
+            InnerVfs::Iso(i) => i.mkd(user, path).await,
         }
     }
 
@@ -280,6 +327,8 @@ impl StorageBackend<User> for ChoosingVfs {
             InnerVfs::OpenDAL(i) => i.rename(user, from, to).await,
             InnerVfs::Cloud(i) => i.rename(user, from, to).await,
             InnerVfs::File(i) => i.rename(user, from, to).await,
+            #[cfg(feature = "sbe_iso")]
+            InnerVfs::Iso(i) => i.rename(user, from, to).await,
         }
     }
 
@@ -292,6 +341,8 @@ impl StorageBackend<User> for ChoosingVfs {
             InnerVfs::OpenDAL(i) => i.rmd(user, path).await,
             InnerVfs::Cloud(i) => i.rmd(user, path).await,
             InnerVfs::File(i) => i.rmd(user, path).await,
+            #[cfg(feature = "sbe_iso")]
+            InnerVfs::Iso(i) => i.rmd(user, path).await,
         }
     }
 
@@ -304,6 +355,8 @@ impl StorageBackend<User> for ChoosingVfs {
             InnerVfs::OpenDAL(i) => i.cwd(user, path).await,
             InnerVfs::Cloud(i) => i.cwd(user, path).await,
             InnerVfs::File(i) => i.cwd(user, path).await,
+            #[cfg(feature = "sbe_iso")]
+            InnerVfs::Iso(i) => i.cwd(user, path).await,
         }
     }
 }


### PR DESCRIPTION
This enables unFTP to use ISO files for read-only storage by using
the `unftp-sbe-iso` crate. It puts all the functionality behind
a feature flag called `sbe_iso`.

In this commit, it is not made part of the default build but perhaps
its not a bad idea to do that.

I've noticed that the other features like `cloud_storage` isn't properly
gated behind its features but I didn't want to make this commit too big
so leaving it to be fixed afterwards.

We may also want to stardardise our feature naming a bit e.g. features
that enable storage backends may start with `sbe_` e.g. `sbe_gcs`.
Similarly, auth back-ends may be named `auth_xxx` e.g. `auth_pam`. This
should make things a bit more intuitive as the features pile up.

Other seemingly unrelated changes:

- Compile against Rust 1.86.0 (Needed this cause unftp-sbe-iso uses the
  2024 edition).
- Removed unused dependency on the `futures` crate.
- Rearanged the features in groups
- let the `gnu` feature list its extentions explicityly
