### PR TITLE
Cleanup features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 - Upgraded dependencies
 - Compile against Rust 1.86.0
 - [#210](https://github.com/bolcom/unFTP/pull/210) Added new `iso` storage back-end gated behind the `sbe_iso` feature.
+- [#211](https://github.com/bolcom/unFTP/pull/211) Cleaned up the unFTP features:
+    - Feature `cloud_storage` is now called `sbe_gcs`
+    - Feature `opendal` is now called `sbe_opendal`
+    - Feature `azblob` is now called `sbe_azblob`
+    - Feature `pam_auth` is now called `auth_pam`
+    - Feature `rest_auth` is now `auth_rest`
+    - Feature `jsonfile_auth` is now `auth_jsonfile`
+    - Fixed the issue where some of these features were not fully behind `cfg` conditionals.
 
 ## 2024-12-14 unftp v0.15.1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,30 +67,37 @@ url = "2.5.4"
 unftp-auth-pam = { version = "0.2.5", optional = true }
 
 [features]
-default = ["rest_auth", "cloud_storage", "jsonfile_auth", "opendal"]
+default = ["auth_rest", "sbe_gcs", "auth_jsonfile", "sbe_opendal"]
 tokio_console = ["dep:console-subscriber", "tokio/tracing"]
 
 ## Storage back-end extentions
-cloud_storage = ["dep:unftp-sbe-gcs"]
-opendal = ["dep:unftp-sbe-opendal", "dep:opendal"]
-azblob = ["opendal/services-azblob"]
+sbe_gcs = ["dep:unftp-sbe-gcs"]
+sbe_opendal = ["dep:unftp-sbe-opendal", "dep:opendal"]
+sbe_azblob = ["sbe_opendal", "opendal/services-azblob"]
 sbe_iso = ["dep:unftp-sbe-iso"]
 
 ## Auth back-end extentions
-pam_auth = ["dep:unftp-auth-pam"]
-rest_auth = ["dep:unftp-auth-rest"]
-jsonfile_auth = ["dep:unftp-auth-jsonfile"]
+auth_pam = ["dep:unftp-auth-pam"]
+auth_rest = ["dep:unftp-auth-rest"]
+auth_jsonfile = ["dep:unftp-auth-jsonfile"]
 
-all_extentions = ["pam_auth", "rest_auth", "jsonfile_auth", "cloud_storage", "opendal", "sbe_iso"]
+# With this we link dynamically to libc and pam. Used to build our target x86_64-unknown-linux-gnu
+gnu = ["auth_pam", "auth_rest", "auth_jsonfile", "sbe_gcs", "sbe_opendal"]
 
-# With this we link dynamically to libc and pam
-gnu = ["pam_auth", "rest_auth", "jsonfile_auth", "cloud_storage", "opendal"]
-
-# All features able to link statically
-musl = ["rest_auth", "cloud_storage", "jsonfile_auth", "azblob"]
+# All features able to link statically. Used to build our target x86_64-unknown-linux-musl
+musl = ["auth_rest", "sbe_gcs", "auth_jsonfile", "sbe_azblob"]
 
 # Features used in our docker builds
 docker = ["musl"]
+
+# Backward-compatible aliases (will be removed at some point)
+all_extentions = ["pam_auth", "rest_auth", "jsonfile_auth", "cloud_storage", "opendal", "sbe_iso"]
+cloud_storage = ["sbe_gcs"]
+opendal = ["sbe_opendal"]
+azblob = ["sbe_azblob"]
+pam_auth = ["auth_pam"]
+rest_auth = ["auth_rest"]
+jsonfile_auth = ["auth_jsonfile"]
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"

--- a/README.md
+++ b/README.md
@@ -9,27 +9,32 @@ When you need to FTP, but don't want to.
 
 ![logo](logo.png)
 
-[**Website**](https://unftp.rs) | [**Docs**](https://unftp.rs/server) | [**libunftp**](https://github.com/bolcom/libunftp)
+[**Website**](https://unftp.rs) | [**Docs**](https://unftp.rs/server) | [**libunftp
+**](https://github.com/bolcom/libunftp)
 
-unFTP is an FTP(S) server written in [Rust](https://www.rust-lang.org) and built on top of [libunftp](https://github.com/bolcom/libunftp) and the [Tokio](https://tokio.rs) asynchronous run-time. It is **un**like your normal FTP server in that it provides:
+unFTP is an FTP(S) server written in [Rust](https://www.rust-lang.org) and built on top
+of [libunftp](https://github.com/bolcom/libunftp) and the [Tokio](https://tokio.rs) asynchronous run-time. It is **un**
+like your normal FTP server in that it provides:
 
-- Configurable Authentication (e.g. Anonymous, [PAM](https://en.wikipedia.org/wiki/Linux_PAM) or a JSON file).
+- Configurable Authentication (e.g. Anonymous, [PAM](https://en.wikipedia.org/wiki/Linux_PAM), a JSON file or HTTP).
 - Configurable storage back-ends (e.g. [GCS](https://cloud.google.com/storage/) or filesystem)
+- Configurable notifications (e.g. events over [Google Pub/Sub](https://cloud.google.com/pubsub/docs/overview))
 - An HTTP server with health endpoints for use for example in Kubernetes for readiness and liveness probes.
 - Integration with [Prometheus](https://prometheus.io) for monitoring.
 - A proxy protocol mode for use behind proxies like HA Proxy and Nginx.
-- Structured logging and the ability to ship logs to a Redis instance.
+- Structured logging and the ability to ship logs to [Google Cloud Logging](https://cloud.google.com/logging) or a Redis
+  instance.
 
-With unFTP, you can present RFC compliant FTP(S) to the outside world while freeing yourself to use modern APIs and 
+With unFTP, you can present RFC compliant FTP(S) to the outside world while freeing yourself to use modern APIs and
 techniques on the inside of your perimeter.
 
 ## Installation and Usage
 
 User documentation are available on our website [unftp.rs](https://unftp.rs)
 
-## Docker image
+## Provided Docker Images
 
-The project contains templated Dockerfiles . To get a list of available commands, run:
+The project contains templated Dockerfiles . To get a list of available commands to create them, run:
 
 ```sh
 make help
@@ -37,9 +42,13 @@ make help
 
 We offer 3 different options for building an unFTP docker image:
 
-- `scratch`: builds the binary in [rust:slim](https://hub.docker.com/_/rust) and deploys in a `FROM scratch` image. The unFTP binary is statically linked using [musl libc](https://www.musl-libc.org/).
-- `alpine` (default): builds in [rust:slim](https://hub.docker.com/_/rust) and deploy in alpine. This image is built with musl instead of a full-blown libc. The unFTP binary is statically linked using [musl libc](https://www.musl-libc.org/).
-- `alpine-debug`: same images as `alpine` but using the debug build of unftp and adds tools like [lftp](https://lftp.yar.ru/) and [CurlFtpFS](http://curlftpfs.sourceforge.net/) while also running as root.
+- `scratch`: builds the binary in [rust:slim](https://hub.docker.com/_/rust) and deploys in a `FROM scratch` image. The
+  unFTP binary is statically linked using [musl libc](https://www.musl-libc.org/).
+- `alpine` (default): builds in [rust:slim](https://hub.docker.com/_/rust) and deploy in alpine. This image is built
+  with musl instead of a full-blown libc. The unFTP binary is statically linked
+  using [musl libc](https://www.musl-libc.org/).
+- `alpine-debug`: same images as `alpine` but using the debug build of unftp and adds tools
+  like [lftp](https://lftp.yar.ru/) and [CurlFtpFS](http://curlftpfs.sourceforge.net/) while also running as root.
 
 To build the alpine docker image:
 
@@ -47,12 +56,12 @@ To build the alpine docker image:
 make docker-image-alpine
 ```
 
-Alternatively you can download pre-made images from [docker hub](https://hub.docker.com/r/bolcom/unftp/tags). 
+Alternatively you can download pre-made images from [docker hub](https://hub.docker.com/r/bolcom/unftp/tags).
 
 ## Enabling tokio-console
 
-You can use [tokio-console](https://github.com/tokio-rs/console) to analyze async tasks running in unFTP. To do this you 
-need to compile a build or run with the `tokio_console` feature enabled while also enabling the `tokio_unstable cfg`. 
+You can use [tokio-console](https://github.com/tokio-rs/console) to analyze async tasks running in unFTP. To do this you
+need to compile a build or run with the `tokio_console` feature enabled while also enabling the `tokio_unstable cfg`.
 
 For example:
 
@@ -63,17 +72,44 @@ RUSTFLAGS="--cfg tokio_unstable" cargo build --features tokio_console
 or:
 
 ```shell
-RUSTFLAGS="--cfg tokio_unstable" cargo run --features tokio_console -- -vv
+RUSTFLAGS="--cfg tokio_unstable" cargo run --features tokio_console -- -vv --auth-type=anonymous
 ```
 
 unFTP will listen on default port 6669 for connections from tokio-console.
 
+## Selective compiling
+
+The unFTP `Cargo.toml` file lists features that allows enabling or disabling storage and authentication back-ends.
+
+These are the default ones: "auth_rest", "sbe_gcs", "auth_jsonfile", "sbe_opendal".
+
+The binary called `unftp_x86_64-unknown-linux-gnu` that we provide via the unFTP GitHub releases also enables
+`auth_pam`.
+
+### 📦 Storage Back-end Extensions
+
+| Feature       | Description                                                                                                            |
+|---------------|------------------------------------------------------------------------------------------------------------------------|
+| `sbe_azblob`  | Enables Azure Blob Storage support via [`unftp-sbe-opendal`](https://crates.io/crates/unftp-sbe-opendal).              |
+| `sbe_gcs`     | Enables Google Cloud Storage support via [`unftp-sbe-gcs`](https://crates.io/crates/unftp-sbe-gcs).                    |
+| `sbe_iso`     | Enables serving ISO 9660 images as FTP storage backends via [`unftp-sbe-iso`](https://crates.io/crates/unftp-sbe-iso). |
+| `sbe_opendal` | Enables generic cloud storage support using [`unftp-sbe-opendal`](https://crates.io/crates/unftp-sbe-opendal).         |
+
+### 🔐 Auth Back-end Extensions
+
+| Feature         | Description                                                                                                              |
+|-----------------|--------------------------------------------------------------------------------------------------------------------------|
+| `auth_jsonfile` | Enables authentication from a local JSON file via [`unftp-auth-jsonfile`](https://crates.io/crates/unftp-auth-jsonfile). |
+| `auth_pam`      | Enables authentication via PAM using [`unftp-auth-pam`](https://crates.io/crates/unftp-auth-pam).                        |
+| `auth_rest`     | Enables REST-based authentication using [`unftp-auth-rest`](https://crates.io/crates/unftp-auth-rest).                   |
+
 ## Getting help and staying informed
 
-Support is given on a best effort basis. You are welcome to engage us on [the discussions page](https://github.com/bolcom/unftp/discussions)
+Support is given on a best effort basis. You are welcome to engage us
+on [the discussions page](https://github.com/bolcom/unftp/discussions)
 or create a Github issue.
 
-You can also follow news and talk to us on [Telegram](https://t.me/unftp) 
+You can also follow news and talk to us on [Telegram](https://t.me/unftp)
 
 ## Updating user documentation
 
@@ -90,4 +126,5 @@ You're free to use, modify and distribute this software under the terms of the A
 
 ## See also
 
-- [libunftp](https://github.com/bolcom/libunftp)
+- [libunftp](https://github.com/bolcom/libunftp), the primary crate unFTP server is based on.
+- [libunftp back-ends/extensions on crates.io](https://crates.io/search?q=unftp-)

--- a/src/args.rs
+++ b/src/args.rs
@@ -3,12 +3,19 @@ use clap::{Arg, ArgEnum, Command};
 use std::str::FromStr;
 use strum_macros::{Display, EnumString};
 
+#[cfg(feature = "auth_jsonfile")]
 pub const AUTH_JSON_PATH: &str = "auth-json-path";
+#[cfg(feature = "auth_pam")]
 pub const AUTH_PAM_SERVICE: &str = "auth-pam-service";
+#[cfg(feature = "auth_rest")]
 pub const AUTH_REST_BODY: &str = "auth-rest-body";
+#[cfg(feature = "auth_rest")]
 pub const AUTH_REST_METHOD: &str = "auth-rest-method";
+#[cfg(feature = "auth_rest")]
 pub const AUTH_REST_REGEX: &str = "auth-rest-regex";
+#[cfg(feature = "auth_rest")]
 pub const AUTH_REST_SELECTOR: &str = "auth-rest-selector";
+#[cfg(feature = "auth_rest")]
 pub const AUTH_REST_URL: &str = "auth-rest-url";
 pub const AUTH_TYPE: &str = "auth-type";
 pub const BIND_ADDRESS: &str = "bind-address";
@@ -22,19 +29,31 @@ pub const FTPS_KEY_FILE: &str = "ftps-key-file";
 pub const FTPS_REQUIRED_ON_CONTROL_CHANNEL: &str = "ftps-required-on-control-channel";
 pub const FTPS_REQUIRED_ON_DATA_CHANNEL: &str = "ftps-required-on-data-channel";
 pub const FTPS_TRUST_STORE: &str = "ftps-trust-store";
+#[cfg(feature = "sbe_gcs")]
 pub const GCS_BASE_URL: &str = "sbe-gcs-base-url";
+#[cfg(feature = "sbe_gcs")]
 pub const GCS_BUCKET: &str = "sbe-gcs-bucket";
+#[cfg(feature = "sbe_gcs")]
 pub const GCS_KEY_FILE: &str = "sbe-gcs-key-file";
+#[cfg(feature = "sbe_gcs")]
 pub const GCS_ROOT: &str = "sbe-gcs-root";
+#[cfg(feature = "sbe_gcs")]
 pub const GCS_SERVICE_ACCOUNT: &str = "sbe-gcs-service-account";
 #[cfg(feature = "sbe_iso")]
 pub const ISO_FILE: &str = "sbe-iso-file";
+#[cfg(feature = "sbe_azblob")]
 pub const AZBLOB_ROOT: &str = "sbe-opendal-azblob-root";
+#[cfg(feature = "sbe_azblob")]
 pub const AZBLOB_CONTAINER: &str = "sbe-opendal-azblob-container";
+#[cfg(feature = "sbe_azblob")]
 pub const AZBLOB_ENDPOINT: &str = "sbe-opendal-azblob-endpoint";
+#[cfg(feature = "sbe_azblob")]
 pub const AZBLOB_ACCOUNT_NAME: &str = "sbe-opendal-azblob-account-name";
+#[cfg(feature = "sbe_azblob")]
 pub const AZBLOB_ACCOUNT_KEY: &str = "sbe-opendal-azblob-account-key";
+#[cfg(feature = "sbe_azblob")]
 pub const AZBLOB_SAS_TOKEN: &str = "sbe-opendal-azblob-sas-token";
+#[cfg(feature = "sbe_azblob")]
 pub const AZBLOB_BATCH_MAX_OPERATIONS: &str = "sbe-opendal-azblob-batch-max-operations";
 pub const HTTP_BIND_ADDRESS: &str = "bind-address-http";
 pub const IDLE_SESSION_TIMEOUT: &str = "idle-session-timeout";
@@ -63,8 +82,11 @@ pub const GLOG_LABELS_FILE: &str = "log-google-labels-file";
 #[strum(serialize_all = "lowercase")]
 pub enum AuthType {
     Anonymous,
+    #[cfg(feature = "auth_pam")]
     Pam,
+    #[cfg(feature = "auth_rest")]
     Rest,
+    #[cfg(feature = "auth_jsonfile")]
     Json,
 }
 
@@ -72,7 +94,9 @@ pub enum AuthType {
 #[allow(non_camel_case_types)]
 pub enum StorageBackendType {
     filesystem,
+    #[cfg(feature = "sbe_gcs")]
     gcs,
+    #[cfg(feature = "sbe_azblob")]
     azblob,
     #[cfg(feature = "sbe_iso")]
     iso,
@@ -362,170 +386,27 @@ pub(crate) fn clap_app(tmp_dir: &str) -> Command {
         .arg(
             Arg::new(AUTH_TYPE)
                 .long("auth-type")
-                .value_name("NAME")
-                .help("The type of authorization to use")
+                .value_name("TYPE")
+                .help("The type of authorization back-end to use. \
+                         Possible values could by 'anonymous', 'pam', 'json' or 'rest', but it depends \
+                         on whether unFTP was compiled to include that particular feature.")
                 //.case_insensitive(true)
                 .env("UNFTP_AUTH_TYPE")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::new(AUTH_PAM_SERVICE)
-                .long("auth-pam-service")
-                .value_name("NAME")
-                .help("The name of the PAM service")
-                .env("UNFTP_AUTH_PAM_SERVICE")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::new(AUTH_REST_URL)
-                .long("auth-rest-url")
-                .value_name("URL")
-                .help("Define REST endpoint. {USER}, {PASS} and/or {IP} are replaced by provided credentials and source IP respectively.")
-                .env("UNFTP_AUTH_REST_URL")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::new(AUTH_REST_METHOD)
-                .long("auth-rest-method")
-                .value_name("URL")
-                .help("HTTP method to access REST endpoint")
-                .env("UNFTP_AUTH_REST_METHOD")
-                .default_value("GET")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::new(AUTH_REST_BODY)
-                .long("auth-rest-body")
-                .value_name("TEMPLATE")
-                .help("If HTTP method contains body, it can be specified here. {USER}, {PASS} and/or {IP}\
-                are replaced by provided credentials and source IP respectively.")
-                .env("UNFTP_AUTH_REST_BODY")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::new(AUTH_REST_SELECTOR)
-                .long("auth-rest-selector")
-                .value_name("SELECTOR")
-                .help("Define JSON pointer to fetch from REST response body (RFC6901)")
-                .env("UNFTP_AUTH_REST_SELECTOR")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::new(AUTH_REST_REGEX)
-                .long("auth-rest-regex")
-                .value_name("REGEX")
-                .help("Regular expression to try match against value extracted via selector")
-                .env("UNFTP_AUTH_REST_REGEX")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::new(AUTH_JSON_PATH)
-                .long("auth-json-path")
-                .value_name("PATH")
-                .help("The path to the json authentication file")
-                .env("UNFTP_AUTH_JSON_PATH")
-                .takes_value(true),
+                .takes_value(true)
+                .default_value("anonymous"),
         )
         .arg(
             Arg::new(STORAGE_BACKEND_TYPE)
                 .long("sbe-type")
                 .value_name("TYPE")
-                .help("Sets the storage backend type.")
+                .help("Sets the storage backend type. \
+                          Possible values could by 'filesystem', 'gcs', 'azblob' or 'iso', but it depends \
+                          on whether unFTP was compiled to include that particular feature.")
                 .env("UNFTP_SBE_TYPE")
                 .takes_value(true)
                 .default_value("filesystem"),
         )
-        .arg(
-            Arg::new(GCS_BASE_URL)
-                .long("sbe-gcs-base-url")
-                .value_name("URL")
-                .help("The base url of Google Cloud Storage API")
-                .env("UNFTP_SBE_GCS_BASE_URL")
-                .default_value("https://www.googleapis.com")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::new(GCS_BUCKET)
-                .long("sbe-gcs-bucket")
-                .value_name("BUCKET")
-                .help("The bucket to use for the Google Cloud Storage backend")
-                .env("UNFTP_SBE_GCS_BUCKET")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::new(GCS_KEY_FILE)
-                .long("sbe-gcs-key-file")
-                .value_name("KEY_FILE")
-                .help("The JSON file that contains the service account key for access to Google Cloud Storage.")
-                .env("UNFTP_SBE_GCS_KEY_FILE")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::new(GCS_ROOT)
-                .long("sbe-gcs-root")
-                .value_name("PATH")
-                .help("The root path in the bucket where unFTP will look for and store files.")
-                .env("UNFTP_SBE_GCS_ROOT")
-                .default_value("")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::new(GCS_SERVICE_ACCOUNT)
-                .long("sbe-gcs-service-account")
-                .value_name("SERVICE_ACCOUNT_NAME")
-                .help("The name of the service account to use when authenticating using GKE workload identity.")
-                .env("UNFTP_SBE_GCS_SERVICE_ACCOUNT")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::new(AZBLOB_ROOT)
-            .long("sbe-opendal-azblob-root")
-            .help("Root of this backend. All operations will happen under this root.")
-            .env("UNFTP_SBE_OPENDAL_AZBLOB_ROOT")
-            .takes_value(true))
-        .arg(
-            Arg::new(AZBLOB_CONTAINER)
-            .long("sbe-opendal-azblob-container")
-            .help("Container name of this backend.")
-            .env("UNFTP_SBE_OPENDAL_AZBLOB_CONTAINER")
-            .takes_value(true)
-        )
-        .arg(
-            Arg::new(AZBLOB_ENDPOINT)
-            .long("sbe-opendal-azblob-endpoint")
-            .help("Endpoint of this backend. Endpoint must be full uri.")
-            .env("UNFTP_SBE_OPENDAL_AZBLOB_ENDPOINT")
-            .takes_value(true)
-        )
-        .arg(
-            Arg::new(AZBLOB_ACCOUNT_NAME)
-            .long("sbe-opendal-azblob-account-name")
-            .help("Set account_name of this backend. If account_name is set, we will take user's input first. If not, we will try to load it from environment.")
-            .env("UNFTP_SBE_OPENDAL_AZBLOB_ACCOUNT_NAME")
-            .takes_value(true)
-        )
-        .arg(
-            Arg::new(AZBLOB_ACCOUNT_KEY)
-            .long("sbe-opendal-azblob-account-key")
-            .help("Set account_key of this backend. If account_name is set, we will take user's input first. If not, we will try to load it from environment.")
-            .env("UNFTP_SBE_OPENDAL_AZBLOB_ACCOUNT_KEY")
-            .takes_value(true)
-        )
-        .arg(
-            Arg::new(AZBLOB_SAS_TOKEN)
-            .long("sbe-opendal-azblob-sas-token")
-            .help("Set sas_token of this backend. If account_name is set, we will take user's input first. If not, we will try to load it from environment. See https://learn.microsoft.com/en-us/azure/storage/common/storage-sas-overview for more info.")
-            .env("UNFTP_SBE_OPENDAL_AZBLOB_SAS_TOKEN")
-            .takes_value(true)
-        )
-        .arg(
-            Arg::new(AZBLOB_BATCH_MAX_OPERATIONS)
-            .long("sbe-opendal-azblob-batch-max-operations")
-            .help("Set maximum batch operations of this backend.")
-            .env("UNFTP_SBE_OPENDAL_AZBLOB_BATCH_MAX_OPERATIONS")
-            .takes_value(true)
-        )
-        .arg(
+      .arg(
             Arg::new(IDLE_SESSION_TIMEOUT)
                 .long("idle-session-timeout")
                 .value_name("TIMEOUT_SECONDS")
@@ -636,18 +517,216 @@ pub(crate) fn clap_app(tmp_dir: &str) -> Command {
             .default_value(tmp_dir),
     );
 
+    #[cfg(feature = "sbe_gcs")]
+    {
+        cmd = sbe_gcs_commands(cmd);
+    }
+
+    #[cfg(feature = "sbe_azblob")]
+    {
+        cmd = sbe_azblob_commands(cmd);
+    }
+
     #[cfg(feature = "sbe_iso")]
     {
-        cmd = cmd.arg(
-            Arg::new(ISO_FILE)
-                .long("sbe-iso-file")
-                .value_name("FILE")
-                .help("When the storage backend type is 'iso', this sets the path to the ISO file to serve.")
-                .env("UNFTP_ISO_FILE")
-                .takes_value(true)
-                .requires(STORAGE_BACKEND_TYPE),
-        );
+        cmd = sbe_iso_commands(cmd);
+    }
+
+    #[cfg(feature = "auth_pam")]
+    {
+        cmd = auth_pam_commands(cmd);
+    }
+
+    #[cfg(feature = "auth_jsonfile")]
+    {
+        cmd = auth_jsonfile_commands(cmd);
+    }
+
+    #[cfg(feature = "auth_rest")]
+    {
+        cmd = auth_rest_commands(cmd);
     }
 
     cmd
+}
+
+#[cfg(feature = "sbe_iso")]
+fn sbe_iso_commands(cmd: Command) -> Command {
+    cmd.arg(
+        Arg::new(ISO_FILE)
+            .long("sbe-iso-file")
+            .value_name("FILE")
+            .help("When the storage backend type is 'iso', this sets the path to the ISO file to serve.")
+            .env("UNFTP_ISO_FILE")
+            .takes_value(true)
+            .requires(STORAGE_BACKEND_TYPE),
+    )
+}
+
+#[cfg(feature = "sbe_gcs")]
+fn sbe_gcs_commands(cmd: Command) -> Command {
+    cmd.arg(
+        Arg::new(GCS_BASE_URL)
+            .long("sbe-gcs-base-url")
+            .value_name("URL")
+            .help("The base url of Google Cloud Storage API")
+            .env("UNFTP_SBE_GCS_BASE_URL")
+            .default_value("https://www.googleapis.com")
+            .takes_value(true),
+    )
+        .arg(
+            Arg::new(GCS_BUCKET)
+                .long("sbe-gcs-bucket")
+                .value_name("BUCKET")
+                .help("The bucket to use for the Google Cloud Storage backend")
+                .env("UNFTP_SBE_GCS_BUCKET")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::new(GCS_KEY_FILE)
+                .long("sbe-gcs-key-file")
+                .value_name("KEY_FILE")
+                .help("The JSON file that contains the service account key for access to Google Cloud Storage.")
+                .env("UNFTP_SBE_GCS_KEY_FILE")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::new(GCS_ROOT)
+                .long("sbe-gcs-root")
+                .value_name("PATH")
+                .help("The root path in the bucket where unFTP will look for and store files.")
+                .env("UNFTP_SBE_GCS_ROOT")
+                .default_value("")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::new(GCS_SERVICE_ACCOUNT)
+                .long("sbe-gcs-service-account")
+                .value_name("SERVICE_ACCOUNT_NAME")
+                .help("The name of the service account to use when authenticating using GKE workload identity.")
+                .env("UNFTP_SBE_GCS_SERVICE_ACCOUNT")
+                .takes_value(true),
+        )
+}
+
+#[cfg(feature = "sbe_azblob")]
+fn sbe_azblob_commands(cmd: Command) -> Command {
+    cmd.arg(
+          Arg::new(AZBLOB_ROOT)
+            .long("sbe-opendal-azblob-root")
+            .help("Root of this backend. All operations will happen under this root.")
+            .env("UNFTP_SBE_OPENDAL_AZBLOB_ROOT")
+            .takes_value(true))
+        .arg(
+            Arg::new(AZBLOB_CONTAINER)
+                .long("sbe-opendal-azblob-container")
+                .help("Container name of this backend.")
+                .env("UNFTP_SBE_OPENDAL_AZBLOB_CONTAINER")
+                .takes_value(true)
+        )
+        .arg(
+            Arg::new(AZBLOB_ENDPOINT)
+                .long("sbe-opendal-azblob-endpoint")
+                .help("Endpoint of this backend. Endpoint must be full uri.")
+                .env("UNFTP_SBE_OPENDAL_AZBLOB_ENDPOINT")
+                .takes_value(true)
+        )
+        .arg(
+            Arg::new(AZBLOB_ACCOUNT_NAME)
+                .long("sbe-opendal-azblob-account-name")
+                .help("Set account_name of this backend. If account_name is set, we will take user's input first. If not, we will try to load it from environment.")
+                .env("UNFTP_SBE_OPENDAL_AZBLOB_ACCOUNT_NAME")
+                .takes_value(true)
+        )
+        .arg(
+            Arg::new(AZBLOB_ACCOUNT_KEY)
+                .long("sbe-opendal-azblob-account-key")
+                .help("Set account_key of this backend. If account_name is set, we will take user's input first. If not, we will try to load it from environment.")
+                .env("UNFTP_SBE_OPENDAL_AZBLOB_ACCOUNT_KEY")
+                .takes_value(true)
+        )
+        .arg(
+            Arg::new(AZBLOB_SAS_TOKEN)
+                .long("sbe-opendal-azblob-sas-token")
+                .help("Set sas_token of this backend. If account_name is set, we will take user's input first. If not, we will try to load it from environment. See https://learn.microsoft.com/en-us/azure/storage/common/storage-sas-overview for more info.")
+                .env("UNFTP_SBE_OPENDAL_AZBLOB_SAS_TOKEN")
+                .takes_value(true)
+        )
+        .arg(
+            Arg::new(AZBLOB_BATCH_MAX_OPERATIONS)
+                .long("sbe-opendal-azblob-batch-max-operations")
+                .help("Set maximum batch operations of this backend.")
+                .env("UNFTP_SBE_OPENDAL_AZBLOB_BATCH_MAX_OPERATIONS")
+                .takes_value(true)
+        )
+}
+
+#[cfg(feature = "auth_pam")]
+fn auth_pam_commands(cmd: Command) -> Command {
+    cmd.arg(
+        Arg::new(AUTH_PAM_SERVICE)
+            .long("auth-pam-service")
+            .value_name("NAME")
+            .help("The name of the PAM service")
+            .env("UNFTP_AUTH_PAM_SERVICE")
+            .takes_value(true),
+    )
+}
+
+#[cfg(feature = "auth_jsonfile")]
+fn auth_jsonfile_commands(cmd: Command) -> Command {
+    cmd.arg(
+        Arg::new(AUTH_JSON_PATH)
+            .long("auth-json-path")
+            .value_name("PATH")
+            .help("The path to the json authentication file")
+            .env("UNFTP_AUTH_JSON_PATH")
+            .takes_value(true),
+    )
+}
+
+#[cfg(feature = "auth_rest")]
+fn auth_rest_commands(cmd: Command) -> Command {
+    cmd.arg(
+        Arg::new(AUTH_REST_URL)
+            .long("auth-rest-url")
+            .value_name("URL")
+            .help("Define REST endpoint. {USER}, {PASS} and/or {IP} are replaced by provided credentials and source IP respectively.")
+            .env("UNFTP_AUTH_REST_URL")
+            .takes_value(true),
+    )
+        .arg(
+            Arg::new(AUTH_REST_METHOD)
+                .long("auth-rest-method")
+                .value_name("URL")
+                .help("HTTP method to access REST endpoint")
+                .env("UNFTP_AUTH_REST_METHOD")
+                .default_value("GET")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::new(AUTH_REST_BODY)
+                .long("auth-rest-body")
+                .value_name("TEMPLATE")
+                .help("If HTTP method contains body, it can be specified here. {USER}, {PASS} and/or {IP}\
+                are replaced by provided credentials and source IP respectively.")
+                .env("UNFTP_AUTH_REST_BODY")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::new(AUTH_REST_SELECTOR)
+                .long("auth-rest-selector")
+                .value_name("SELECTOR")
+                .help("Define JSON pointer to fetch from REST response body (RFC6901)")
+                .env("UNFTP_AUTH_REST_SELECTOR")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::new(AUTH_REST_REGEX)
+                .long("auth-rest-regex")
+                .value_name("REGEX")
+                .help("Regular expression to try match against value extracted via selector")
+                .env("UNFTP_AUTH_REST_REGEX")
+                .takes_value(true),
+        )
 }


### PR DESCRIPTION
Fixed the issue where some of these features were not fully behind `cfg` conditionals. For example there was the problem here that even though the `gcs` back-end was disabled, it would show up in the command line arguments and also if you tried to compile with `--no-default-features` you would simply get compiler errors.

Also made the names more consistent:

- Feature `cloud_storage` is now called `sbe_gcs`
- Feature `opendal` is now called `sbe_opendal`
- Feature `azblob` is now called `sbe_azblob`
- Feature `pam_auth` is now called `auth_pam`
- Feature `rest_auth` is now `auth_rest`
- Feature `jsonfile_auth` is now `auth_jsonfile`

I kept the old names for backwards-compatibility for now but perhaps in the future we can remove them in a breaking change.