### PR TITLE
Apply best practices to `cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,12 @@ authors = [
 edition = "2021"
 description = "When you need to FTP, but don't want to. An async, cloud orientated FTP(S) server built on libunftp"
 repository = "https://github.com/bolcom/unFTP"
-homepage = "https://github.com/bolcom/unFTP"
+homepage = "https://unftp.rs"
 license = "Apache-2.0"
 readme = "README.md"
 keywords = ["ftp", "ftps", "server", "gcs"]
 categories = ["network-programming"]
-documentation = "https://github.com/bolcom/unFTP"
+documentation = "https://unftp.rs/server/"
 
 [workspace]
 


### PR DESCRIPTION
* Point the `homepage` field to the actual homepage The [`cargo.toml` manifest documentation](https://doc.rust-lang.org/cargo/reference/manifest.html) explicitly mentions the `homepage` field should not be redundant with the `documentation` or `repository` values and should instead only be used if a dedicated homepage for the project exists.

  Additionally, since users already have a link to the source code (from the `repository` field) we can be more useful to users by linking them to the actual homepage.
* Point the `documentation` field to the documentation page on the website Similarly the `documentation` field should be pointing to a website hosting the project's documentation.